### PR TITLE
fix: preserve permissions across the build/remaster pipeline under a restrictive umask

### DIFF
--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -70,6 +70,10 @@ for ovlDir in usr var; do
 
     # FIX: Aggiunto $MERGED alla lista delle directory da creare
     mkdir -p "$LOWER" "$UPPER" "$WORK" "$MERGED"
+    # L'overlay eredita i bit di upperdir per la root del merge: mkdir -p
+    # non li corregge su una dir preesistente (es. run precedente con umask
+    # ristretto), e senza questo dbus non riesce piu' a leggere /usr o /var.
+    chmod 0755 "$UPPER"
     mountpoint -q "$LOWER" || mount --bind "/$ovlDir" "$LOWER"
     mountpoint -q "$MERGED" || mount -t overlay overlay -o lowerdir="$LOWER",upperdir="$UPPER",workdir="$WORK" "$MERGED"
 done

--- a/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
+++ b/coa/pkg/assets/configs/scripts/bootstrap-liveroot.sh
@@ -11,6 +11,9 @@ OVERLAY="$BASEPATH/.overlay"
 
 # 1. SETUP STRUTTURA
 mkdir -p "$LIVEROOT" "$OVERLAY/upperdir" "$OVERLAY/workdir" "$OVERLAY/lowerdir"
+# LIVEROOT stesso diventa la '/' dello squashfs finale: mkdir -p non corregge
+# i bit su una dir preesistente da un run precedente con umask ristretto.
+chmod 0755 "$LIVEROOT"
 
 # 1.1. SELF-BIND OF LIVEROOT
 # Needed so pacman sees "/" as a mountpoint inside the chroot (otherwise

--- a/coa/pkg/builder/build.go
+++ b/coa/pkg/builder/build.go
@@ -58,7 +58,9 @@ func HandleBuild(d *distro.Distro) {
 	recipe(ctx, dist, data)
 
 	// normalize perms: staging/recipe writes are umask-sensitive, packagers aren't
-	normalizePerms(ctx.StageDir)
+	if err := normalizePerms(ctx.StageDir); err != nil {
+		utils.LogWarning("normalizePerms: %v", err)
+	}
 
 	// 4. Packager
 	packager(ctx, dist, data)

--- a/coa/pkg/builder/build.go
+++ b/coa/pkg/builder/build.go
@@ -57,6 +57,9 @@ func HandleBuild(d *distro.Distro) {
 	// 3. addBuildRecipe
 	recipe(ctx, dist, data)
 
+	// normalize perms: staging/recipe writes are umask-sensitive, packagers aren't
+	normalizePerms(ctx.StageDir)
+
 	// 4. Packager
 	packager(ctx, dist, data)
 }

--- a/coa/pkg/builder/templates/alpine.tmpl
+++ b/coa/pkg/builder/templates/alpine.tmpl
@@ -55,6 +55,7 @@ fishcomp() { return 0; }
 package() {
     mkdir -p "$pkgdir/usr"
     mkdir -p "$pkgdir/etc"
+    chmod 0755 "$pkgdir/usr" "$pkgdir/etc"
 
     cp -a "$startdir/usr/"* "$pkgdir/usr/"
     cp -a "$startdir/etc/"* "$pkgdir/etc/"

--- a/coa/pkg/builder/templates/arch-family.tmpl
+++ b/coa/pkg/builder/templates/arch-family.tmpl
@@ -49,9 +49,10 @@ conflicts=('oa-tools' 'oa-tools-manjaro')
 replaces=('oa-tools' 'oa-tools-manjaro')
 
 package() {
-	# Tracciamo i confini
+	# Tracciamo i confini (chmod perche' mkdir -p e' soggetto a umask)
 	mkdir -p "${pkgdir}/usr"
 	mkdir -p "${pkgdir}/etc"
+	chmod 0755 "${pkgdir}/usr" "${pkgdir}/etc"
 
 	# Usiamo $startdir per puntare alla root dello staging (/tmp/oa-stage-dir)
 	cp -a "${startdir}/usr/"* "${pkgdir}/usr/"

--- a/coa/pkg/builder/templates/fedora.tmpl
+++ b/coa/pkg/builder/templates/fedora.tmpl
@@ -52,6 +52,7 @@ necessary tools for Linux system remastering and administration.
 # Tracciamo i confini nella "buildroot" temporanea di RPM
 mkdir -p %{buildroot}/usr
 mkdir -p %{buildroot}/etc
+chmod 0755 %{buildroot}/usr %{buildroot}/etc
 
 # Copiamo i file dal nostro staging (che gli passeremo via riga di comando come _stagedir)
 cp -a %{_stagedir}/usr/* %{buildroot}/usr/

--- a/coa/pkg/builder/templates/opensuse.tmpl
+++ b/coa/pkg/builder/templates/opensuse.tmpl
@@ -46,6 +46,7 @@ necessary tools for Linux system remastering and administration.
 %install
 mkdir -p %{buildroot}/usr
 mkdir -p %{buildroot}/etc
+chmod 0755 %{buildroot}/usr %{buildroot}/etc
 
 cp -a %{_stagedir}/usr/* %{buildroot}/usr/
 cp -a %{_stagedir}/etc/* %{buildroot}/etc/

--- a/coa/pkg/builder/u_normalize-perms.go
+++ b/coa/pkg/builder/u_normalize-perms.go
@@ -1,0 +1,27 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// normalizePerms forces standard, umask-independent permissions on the whole
+// stage tree (0755 dirs, 0755 executables, 0644 other files) right before
+// packaging. os.MkdirAll/OpenFile apply the caller's umask, so a restrictive
+// umask (e.g. 027) silently ships root-only binaries and dirs; owner bits are
+// never masked by a conventional umask, so info.Mode()&0100 still reliably
+// tells executables apart from plain files.
+func normalizePerms(root string) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.Mode()&os.ModeSymlink != 0 {
+			return err
+		}
+		if info.IsDir() {
+			return os.Chmod(path, 0755)
+		}
+		if info.Mode()&0100 != 0 {
+			return os.Chmod(path, 0755)
+		}
+		return os.Chmod(path, 0644)
+	})
+}

--- a/coa/pkg/builder/u_normalize-perms.go
+++ b/coa/pkg/builder/u_normalize-perms.go
@@ -1,27 +1,31 @@
 package builder
 
 import (
+	"coa/pkg/utils"
 	"os"
 	"path/filepath"
 )
 
-// normalizePerms forces standard, umask-independent permissions on the whole
-// stage tree (0755 dirs, 0755 executables, 0644 other files) right before
-// packaging. os.MkdirAll/OpenFile apply the caller's umask, so a restrictive
-// umask (e.g. 027) silently ships root-only binaries and dirs; owner bits are
-// never masked by a conventional umask, so info.Mode()&0100 still reliably
-// tells executables apart from plain files.
+// normalizePerms forces standard, umask-independent permissions (0755 dirs
+// and executables, 0644 everything else) on the whole stage tree, since
+// MkdirAll/OpenFile apply the caller's umask. A chmod failure is logged and
+// skipped rather than aborting filepath.Walk's whole traversal.
 func normalizePerms(root string) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.Mode()&os.ModeSymlink != 0 {
-			return err
+		if err != nil {
+			utils.LogWarning("normalizePerms: %s: %v", path, err)
+			return nil
 		}
-		if info.IsDir() {
-			return os.Chmod(path, 0755)
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
 		}
-		if info.Mode()&0100 != 0 {
-			return os.Chmod(path, 0755)
+		mode := os.FileMode(0644)
+		if info.IsDir() || info.Mode()&0100 != 0 {
+			mode = 0755
 		}
-		return os.Chmod(path, 0644)
+		if err := os.Chmod(path, mode); err != nil {
+			utils.LogWarning("normalizePerms: chmod %s: %v", path, err)
+		}
+		return nil
 	})
 }

--- a/coa/pkg/worker/template.go
+++ b/coa/pkg/worker/template.go
@@ -95,6 +95,13 @@ func RunTemplate(payload []byte) error {
 		return fmt.Errorf("error writing file: %w", err)
 	}
 
+	// WriteFile's mode goes through the caller's umask like any open(2);
+	// force it explicitly so a restrictive umask can't silently shrink it
+	// (e.g. this polkit policy needing to stay world-readable for polkitd).
+	if err := os.Chmod(fullPath, perms); err != nil {
+		return fmt.Errorf("error setting permissions for %s: %w", fullPath, err)
+	}
+
 	fmt.Printf("📦 [worker] Template rendered and written to: %s\n", fullPath)
 	return nil
 }

--- a/coa/pkg/worker/template.go
+++ b/coa/pkg/worker/template.go
@@ -85,6 +85,11 @@ func RunTemplate(payload []byte) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("unable to create directories for %s: %w", fullPath, err)
 	}
+	// MkdirAll's mode is umask-shrunk like any mkdir(2); force it explicitly,
+	// same reasoning as the file chmod below.
+	if err := os.Chmod(dir, 0755); err != nil {
+		return fmt.Errorf("error setting permissions for %s: %w", dir, err)
+	}
 
 	perms := config.Params.Permissions
 	if perms == 0 {

--- a/oa/src/oa-yocto.c
+++ b/oa/src/oa-yocto.c
@@ -48,6 +48,10 @@ int yocto_sanitize_file(const char *src_path, int min_id, int max_id) {
 
     fclose(src);
     fclose(dst);
+
+    // passwd/group must stay world-readable; fopen("w")'s creation mode is
+    // umask-shrunk otherwise, and rename() never fixes it back up.
+    chmod(tmp_path, 0644);
     return rename(tmp_path, src_path);
 }
 
@@ -219,6 +223,7 @@ int yocto_sanitize_subid(const char *subid_path, const char *passwd_path) {
 
     fclose(src);
     fclose(dst);
+    chmod(tmp_path, 0644);
     return rename(tmp_path, subid_path);
 }
 
@@ -267,5 +272,6 @@ void yocto_add_user_to_groups(const char *group_file, const char *username, cJSO
 
     fclose(src);
     fclose(dst);
+    chmod(tmp_file, 0644);
     rename(tmp_file, group_file);
 }


### PR DESCRIPTION
## Summary
A restrictive build-host umask (e.g. `027`) silently shrinks permissions everywhere a file or directory gets created during staging, templating, and packaging — `os.MkdirAll`/`OpenFile`/`fopen("w")`/`mkdir -p` all apply the caller's umask like any other creation syscall. Confirmed real-world impact: a locally-built `.pkg.tar.zst` shipped `/usr`, `/usr/bin`, `/etc/penguins-eggs.d/...` at `0750` instead of `0755` (pacman warns on install), and on the live-ISO side an umask-shrunk `/etc/passwd`/`/etc/group` made `polkitd` unable to read them after dropping root, cascading into a broken lightdm/AccountsService session at boot.

- Normalize the overlay `upperdir` root and `$LIVEROOT` itself (squashed directly as the live image's `/`) in `bootstrap-liveroot.sh`.
- Force `chmod` after template writes in `worker/template.go`, for both the rendered file and its parent directory.
- Walk and normalize the whole stage tree (`normalizePerms`) before packaging, logging (not aborting on) any individual chmod failure.
- Each packager's own `package()`/`%install` step re-creates its `pkgdir`/`buildroot` top-level dirs via a fresh `mkdir -p` *after* the stage tree is normalized — same bug, one step later. Fixed for arch/manjaro, alpine, fedora, and opensuse templates (debian packs the stage tree directly via `dpkg-deb`, unaffected).
- `oa-yocto.c`: `yocto_sanitize_file/_subid` and `yocto_add_user_to_groups` rewrite `passwd`/`group`/`subid` via temp-file-then-rename but never fixed the temp file's mode; `chmod(tmp_path, 0644)` added, mirroring the pattern `yocto_sanitize_shadow/_gshadow` already used correctly.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `oa` C build clean (`-Wall -Wextra`, no warnings)
- [x] VM-installed a remastered ISO built from this branch via Calamares; confirmed boot and install complete
- [ ] Confirm `pacman -U` on the resulting package no longer warns about directory-permission mismatches (packaging-template fix, not yet re-tested after latest commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)