### PR TITLE
fix: detect Openbox sessions in skel generation

### DIFF
--- a/coa/pkg/xdg/skel.go
+++ b/coa/pkg/xdg/skel.go
@@ -85,6 +85,12 @@ func HandleSkel(targetUser string) {
 		rsyncIfExist(filepath.Join(userHome, ".config"), "/etc/skel/")
 		rsyncIfExist(filepath.Join(userHome, ".gtkrc-2.0"), "/etc/skel/")
 
+	} else if hasExecutable("openbox") || hasExecutable("openbox-session") {
+		// OPENBOX (Mabox, etc.) - panel/compositor/theme tools each own a
+		// top-level ~/.config dir (openbox, tint2, conky, ...), so copy it whole
+		rsyncIfExist(filepath.Join(userHome, ".config"), "/etc/skel/")
+		rsyncIfExist(filepath.Join(userHome, ".gtkrc-2.0"), "/etc/skel/")
+
 	} else if hasExecutable("xfce4-session") {
 		// XFCE4
 		utils.ExecQuiet("mkdir -p /etc/skel/.config")


### PR DESCRIPTION
## Summary
`coa tools skel` (`HandleSkel` in `coa/pkg/xdg/skel.go`) special-cases GNOME/Cinnamon/MATE, KDE Plasma, LXQt, LXDE, and XFCE4 to decide what to copy from the source user's home into `/etc/skel`, but had no branch for Openbox — so any Openbox-based distro (Mabox Linux being the concrete case that surfaced this) never got `.config` copied at all. The live/installed user ends up with none of the operator's actual panel/theme/menu setup (tint2, jgmenu, openbox itself all live as top-level dirs directly under `~/.config`, not nested under one folder the way LXQt/XFCE4 are), even after explicitly running `coa tools skel`.

Adds an Openbox branch (detected via `openbox`/`openbox-session` on `$PATH`) that copies the whole `.config` plus `.gtkrc-2.0`, mirroring the existing LXDE branch's pattern since Openbox setups have the same "many independent top-level `.config` dirs" shape rather than one nested folder.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] Rebuilt `coa` locally and ran `sudo coa tools skel` on a real Mabox host — log now shows `-> Copying: /home/<user>/.config` (previously absent)
- [x] Remastered and booted the resulting ISO in a VM; jgmenu/tint2/openbox now reflect the source user's actual configuration instead of the distro-default fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)