### PR TITLE
Fix/wardrobe verify with dpkg

### DIFF
--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -84,23 +84,29 @@ func getAvailablePackages() map[string]struct{} {
 	return available
 }
 
-func installWithRetries(packages []string, retries int) {
-	installPackagesImpl(packages, retries, false)
+// installWithRetries installs packages, falling back to one-by-one
+// installation on bulk failure so a single broken package does not
+// prevent the rest from being installed. Returns the packages that
+// could not be installed (including any not found in apt's cache),
+// so the caller can report them to the user.
+func installWithRetries(packages []string, retries int) []string {
+	return installPackagesImpl(packages, retries, false)
 }
 
 // installNoRecommends installs packages with --no-install-recommends.
-func installNoRecommends(packages []string) {
-	installPackagesImpl(packages, 3, true)
+// Returns the packages that could not be installed.
+func installNoRecommends(packages []string) []string {
+	return installPackagesImpl(packages, 3, true)
 }
 
-func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+func installPackagesImpl(packages []string, retries int, noRecommends bool) []string {
 	if len(packages) == 0 {
-		return
+		return nil
 	}
 
 	if _, err := exec.LookPath("apt-get"); err != nil {
 		printAiPrompt(packages)
-		return
+		return nil
 	}
 
 	available := getAvailablePackages()
@@ -125,7 +131,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 	if len(toInstall) == 0 {
 		logToFile("No valid packages to install.")
-		return
+		return missing
 	}
 
 	pkgString := strings.Join(toInstall, " ")
@@ -148,41 +154,51 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 	// documented workaround for this class of bug.
 	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
 
-	for i := 1; i <= retries; i++ {
-		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
-		if err := utils.Exec(cmd); err == nil {
-			logToFile("✅ Package installation completed.")
-			return
-		}
+	logToFile(fmt.Sprintf("Installing %d packages in bulk...", len(toInstall)))
+	if err := utils.Exec(cmd); err == nil {
+		logToFile("✅ Package installation completed.")
+		return missing
+	}
 
-		// Fallback: install one by one so a single broken package
-		// does not prevent the rest from being installed.
-		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
-		var failed []string
-		for _, pkg := range toInstall {
+	// Fallback: install one by one so a single broken package does not
+	// prevent the rest from being installed. Packages that still fail
+	// after `retries` individual attempts are given up on and reported.
+	logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
+	pending := toInstall
+	for attempt := 1; attempt <= retries && len(pending) > 0; attempt++ {
+		var stillFailing []string
+		for _, pkg := range pending {
 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
-				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
-				failed = append(failed, pkg)
+				stillFailing = append(stillFailing, pkg)
 			}
 		}
-
-		if len(failed) > 0 {
-			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
-		} else {
-			logToFile("✅ All packages installed successfully (one by one).")
+		pending = stillFailing
+		if len(pending) > 0 && attempt < retries {
+			logToFile(fmt.Sprintf("⚠️  %d packages still failing after attempt %d/%d, retrying: %v", len(pending), attempt, retries, pending))
 		}
-		return
 	}
+
+	if len(pending) > 0 {
+		logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(pending), pending))
+	} else {
+		logToFile("✅ All packages installed successfully (one by one).")
+	}
+
+	return append(missing, pending...)
 }
 
 // installInteractive installs packages without suppressing debconf prompts.
 // Use this for packages that require user interaction (e.g. license acceptance).
 // Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
 // live prompt from the real terminal (see the comment in installPackagesImpl).
-func installInteractive(packages []string) {
+// Returns the packages that could not be installed (missing from apt's
+// cache, or the whole batch if the bulk apt-get call failed -- interactive
+// packages are typically few and license-related, so we don't attempt the
+// one-by-one isolation used for regular packages).
+func installInteractive(packages []string) []string {
 	if len(packages) == 0 {
-		return
+		return nil
 	}
 
 	available := getAvailablePackages()
@@ -206,7 +222,7 @@ func installInteractive(packages []string) {
 	}
 
 	if len(toInstall) == 0 {
-		return
+		return missing
 	}
 
 	pkgString := strings.Join(toInstall, " ")
@@ -214,7 +230,9 @@ func installInteractive(packages []string) {
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
+		return append(missing, toInstall...)
 	}
+	return missing
 }
 
 // removePackages removes packages that the vendor does not want on the system.

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -170,7 +170,18 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
 		for _, pkg := range pending {
 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
-				stillFailing = append(stillFailing, pkg)
+				// apt-get's exit code alone is not reliable evidence that
+				// THIS package failed: dpkg processes deferred triggers
+				// from unrelated packages during this same invocation, and
+				// a trigger failure poisons the exit code of whatever
+				// install call happened to flush it, even though the
+				// package we actually asked for installed correctly.
+				// Double-check with dpkg before believing the failure.
+				if isPackageInstalled(pkg) {
+					logToFile(fmt.Sprintf("ℹ️  apt-get reported an error installing %s, but dpkg confirms it is installed correctly (likely an unrelated deferred trigger) -- not counting as failed.", pkg))
+				} else {
+					stillFailing = append(stillFailing, pkg)
+				}
 			}
 		}
 		pending = stillFailing
@@ -186,6 +197,19 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
 	}
 
 	return append(missing, pending...)
+}
+
+// isPackageInstalled reports whether dpkg considers pkg to be correctly
+// and fully installed ("install ok installed"), independent of what the
+// most recent apt-get call's exit code said. Used to avoid false-positive
+// failure reports caused by unrelated deferred dpkg triggers poisoning an
+// otherwise-successful package's apt-get exit code.
+func isPackageInstalled(pkg string) bool {
+	out, err := utils.ExecCapture(fmt.Sprintf("dpkg-query -W -f='${Status}' %s 2>/dev/null", pkg))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(out, "install ok installed")
 }
 
 // installInteractive installs packages without suppressing debconf prompts.
@@ -229,8 +253,19 @@ func installInteractive(packages []string) []string {
 	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
-		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
-		return append(missing, toInstall...)
+		// Don't trust apt-get's exit code blindly: check each package
+		// against dpkg before reporting it as failed (see the comment on
+		// isPackageInstalled for why apt-get's exit code alone can lie).
+		var stillFailing []string
+		for _, pkg := range toInstall {
+			if !isPackageInstalled(pkg) {
+				stillFailing = append(stillFailing, pkg)
+			}
+		}
+		if len(stillFailing) > 0 {
+			logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", stillFailing))
+		}
+		return append(missing, stillFailing...)
 	}
 	return missing
 }

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -136,9 +136,17 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 	// readline: accepts low-priority defaults automatically but shows
 	// critical prompts (e.g. firmware license agreements) to the user.
-	// PAGER=cat prevents firmware license scripts from paginating with
-	// 'more' or 'less', which would block unattended installation.
-	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
+	// Dpkg::Use-Pty=0: apt normally runs dpkg inside its own internal
+	// pseudo-terminal so it can both show the output live and log a copy
+	// to /var/log/apt/term.log. That mirroring has known bugs (Debian
+	// #765687, #860931) where the copy written to term.log succeeds but
+	// the live mirror to the real terminal is silently dropped -- the
+	// user never sees the prompt (or sees it truncated, e.g. "[Más]"
+	// glued to the next shell prompt) even though stdin/stdout are
+	// correctly wired to a real tty. Disabling apt's internal pty makes
+	// dpkg/debconf inherit our own stdio directly instead, which is the
+	// documented workaround for this class of bug.
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
 
 	for i := 1; i <= retries; i++ {
 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
@@ -152,7 +160,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
 		var failed []string
 		for _, pkg := range toInstall {
-			singleCmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkg)
+			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
 				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
 				failed = append(failed, pkg)
@@ -170,7 +178,8 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 // installInteractive installs packages without suppressing debconf prompts.
 // Use this for packages that require user interaction (e.g. license acceptance).
-// PAGER=cat is set to avoid firmware license scripts paginating with 'more'/'less'.
+// Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+// live prompt from the real terminal (see the comment in installPackagesImpl).
 func installInteractive(packages []string) {
 	if len(packages) == 0 {
 		return
@@ -201,7 +210,7 @@ func installInteractive(packages []string) {
 	}
 
 	pkgString := strings.Join(toInstall, " ")
-	cmd := fmt.Sprintf("PAGER=cat apt-get install -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
@@ -217,13 +226,13 @@ func removePackages(packages []string) {
 	}
 
 	pkgString := strings.Join(packages, " ")
-	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Removing packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some packages could not be removed (may not be installed): %v", err))
 	}
 
-	utils.Exec("PAGER=cat DEBIAN_FRONTEND=readline apt-get autoremove -y")
+	utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
 }
 
 func printAiPrompt(packages []string) {

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -65,6 +65,19 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 func applySuit(dir string, suit *Suit) error {
 	if suit.Sequence != nil && suit.Sequence.Repositories != nil {
 		setupRepositories(suit.Sequence.Repositories, suit.Name)
+
+		// A repository that was just added is invisible to apt until the
+		// package index is refreshed. Without this, every package that
+		// only exists in a repo added above silently fails to be found
+		// by getAvailablePackages() in wear-logic.go and gets skipped
+		// rather than installed -- with no build-time error, only a
+		// line in /var/log/coa-tailor.log. This is what left every
+		// quirinux-* package uninstalled even though the repo's own
+		// .deb installed correctly.
+		utils.LogNormal("[%s] Refreshing package index after repository changes...", suit.Name)
+		if err := utils.Exec("apt-get update"); err != nil {
+			utils.LogNormal("[%s] WARNING: apt-get update failed, newly added repositories may be unusable: %v", suit.Name, err)
+		}
 	}
 
 	if len(suit.Packages) > 0 {

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func Wear(costumeName string, noAcc bool, noFirm bool) error {
@@ -33,7 +34,8 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 	}
 
 	utils.LogNormal("--- Applying Costume: %s ---", suit.Name)
-	if err := applySuit(costumeDir, suit); err != nil {
+	failedPackages, err := applySuit(costumeDir, suit)
+	if err != nil {
 		return err
 	}
 
@@ -44,7 +46,8 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 			if accYaml := findYaml(accDir); accYaml != "" {
 				if accSuit, err := loadSuit(accYaml); err == nil {
 					utils.LogNormal("Accessory: %s", accName)
-					applySuit(accDir, accSuit)
+					accFailed, _ := applySuit(accDir, accSuit)
+					failedPackages = append(failedPackages, accFailed...)
 				}
 			}
 		}
@@ -55,6 +58,13 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 
 	utils.LogNormal("✅ Costume applied successfully!")
 
+	if len(failedPackages) > 0 {
+		msg := fmt.Sprintf("⚠️  %d package(s) could not be installed:\n  - %s",
+			len(failedPackages), strings.Join(failedPackages, "\n  - "))
+		utils.LogNormal(utils.ColorYellow + msg + utils.ColorReset)
+		logToFile(msg)
+	}
+
 	if suit.Reboot {
 		utils.LogNormal(utils.ColorYellow + "This costume recommends a reboot to finish applying all changes." + utils.ColorReset)
 	}
@@ -62,7 +72,12 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 	return nil
 }
 
-func applySuit(dir string, suit *Suit) error {
+// applySuit applies a costume/accessory and returns the list of packages
+// that could not be installed (across packages, packages_no_install_recommends
+// and packages_interactive), so the caller can report them to the user.
+func applySuit(dir string, suit *Suit) ([]string, error) {
+	var failedPackages []string
+
 	if suit.Sequence != nil && suit.Sequence.Repositories != nil {
 		setupRepositories(suit.Sequence.Repositories, suit.Name)
 
@@ -82,19 +97,19 @@ func applySuit(dir string, suit *Suit) error {
 
 	if len(suit.Packages) > 0 {
 		utils.LogNormal("[%s] Attempting package installation: %v", suit.Name, suit.Packages)
-		installWithRetries(suit.Packages, 3)
+		failedPackages = append(failedPackages, installWithRetries(suit.Packages, 3)...)
 	} else {
 		utils.LogNormal("[%s] No packages to install.", suit.Name)
 	}
 
 	if len(suit.PackagesNoRecommends) > 0 {
 		utils.LogNormal("[%s] Installing packages without recommends: %v", suit.Name, suit.PackagesNoRecommends)
-		installNoRecommends(suit.PackagesNoRecommends)
+		failedPackages = append(failedPackages, installNoRecommends(suit.PackagesNoRecommends)...)
 	}
 
 	if len(suit.PackagesInteractive) > 0 {
 		utils.LogNormal("[%s] Installing interactive packages (license prompts may appear): %v", suit.Name, suit.PackagesInteractive)
-		installInteractive(suit.PackagesInteractive)
+		failedPackages = append(failedPackages, installInteractive(suit.PackagesInteractive)...)
 	}
 
 	if len(suit.PackagesRemove) > 0 {
@@ -129,7 +144,7 @@ func applySuit(dir string, suit *Suit) error {
 		}
 	}
 
-	return nil
+	return failedPackages, nil
 }
 
 func copySkelToUser() {

--- a/fix1-report-failed.patch
+++ b/fix1-report-failed.patch
@@ -1,0 +1,234 @@
+diff --git a/coa/pkg/tailor/wear-logic.go b/coa/pkg/tailor/wear-logic.go
+index 2ff854c..62d9ce6 100644
+--- a/coa/pkg/tailor/wear-logic.go
++++ b/coa/pkg/tailor/wear-logic.go
+@@ -84,23 +84,29 @@ func getAvailablePackages() map[string]struct{} {
+ 	return available
+ }
+ 
+-func installWithRetries(packages []string, retries int) {
+-	installPackagesImpl(packages, retries, false)
++// installWithRetries installs packages, falling back to one-by-one
++// installation on bulk failure so a single broken package does not
++// prevent the rest from being installed. Returns the packages that
++// could not be installed (including any not found in apt's cache),
++// so the caller can report them to the user.
++func installWithRetries(packages []string, retries int) []string {
++	return installPackagesImpl(packages, retries, false)
+ }
+ 
+ // installNoRecommends installs packages with --no-install-recommends.
+-func installNoRecommends(packages []string) {
+-	installPackagesImpl(packages, 3, true)
++// Returns the packages that could not be installed.
++func installNoRecommends(packages []string) []string {
++	return installPackagesImpl(packages, 3, true)
+ }
+ 
+-func installPackagesImpl(packages []string, retries int, noRecommends bool) {
++func installPackagesImpl(packages []string, retries int, noRecommends bool) []string {
+ 	if len(packages) == 0 {
+-		return
++		return nil
+ 	}
+ 
+ 	if _, err := exec.LookPath("apt-get"); err != nil {
+ 		printAiPrompt(packages)
+-		return
++		return nil
+ 	}
+ 
+ 	available := getAvailablePackages()
+@@ -125,7 +131,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 
+ 	if len(toInstall) == 0 {
+ 		logToFile("No valid packages to install.")
+-		return
++		return missing
+ 	}
+ 
+ 	pkgString := strings.Join(toInstall, " ")
+@@ -148,41 +154,51 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 	// documented workaround for this class of bug.
+ 	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
+ 
+-	for i := 1; i <= retries; i++ {
+-		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
+-		if err := utils.Exec(cmd); err == nil {
+-			logToFile("✅ Package installation completed.")
+-			return
+-		}
++	logToFile(fmt.Sprintf("Installing %d packages in bulk...", len(toInstall)))
++	if err := utils.Exec(cmd); err == nil {
++		logToFile("✅ Package installation completed.")
++		return missing
++	}
+ 
+-		// Fallback: install one by one so a single broken package
+-		// does not prevent the rest from being installed.
+-		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
+-		var failed []string
+-		for _, pkg := range toInstall {
++	// Fallback: install one by one so a single broken package does not
++	// prevent the rest from being installed. Packages that still fail
++	// after `retries` individual attempts are given up on and reported.
++	logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
++	pending := toInstall
++	for attempt := 1; attempt <= retries && len(pending) > 0; attempt++ {
++		var stillFailing []string
++		for _, pkg := range pending {
+ 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
+ 			if err := utils.Exec(singleCmd); err != nil {
+-				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
+-				failed = append(failed, pkg)
++				stillFailing = append(stillFailing, pkg)
+ 			}
+ 		}
+-
+-		if len(failed) > 0 {
+-			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
+-		} else {
+-			logToFile("✅ All packages installed successfully (one by one).")
++		pending = stillFailing
++		if len(pending) > 0 && attempt < retries {
++			logToFile(fmt.Sprintf("⚠️  %d packages still failing after attempt %d/%d, retrying: %v", len(pending), attempt, retries, pending))
+ 		}
+-		return
+ 	}
++
++	if len(pending) > 0 {
++		logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(pending), pending))
++	} else {
++		logToFile("✅ All packages installed successfully (one by one).")
++	}
++
++	return append(missing, pending...)
+ }
+ 
+ // installInteractive installs packages without suppressing debconf prompts.
+ // Use this for packages that require user interaction (e.g. license acceptance).
+ // Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+ // live prompt from the real terminal (see the comment in installPackagesImpl).
+-func installInteractive(packages []string) {
++// Returns the packages that could not be installed (missing from apt's
++// cache, or the whole batch if the bulk apt-get call failed -- interactive
++// packages are typically few and license-related, so we don't attempt the
++// one-by-one isolation used for regular packages).
++func installInteractive(packages []string) []string {
+ 	if len(packages) == 0 {
+-		return
++		return nil
+ 	}
+ 
+ 	available := getAvailablePackages()
+@@ -206,7 +222,7 @@ func installInteractive(packages []string) {
+ 	}
+ 
+ 	if len(toInstall) == 0 {
+-		return
++		return missing
+ 	}
+ 
+ 	pkgString := strings.Join(toInstall, " ")
+@@ -214,7 +230,9 @@ func installInteractive(packages []string) {
+ 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
+ 	if err := utils.Exec(cmd); err != nil {
+ 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
++		return append(missing, toInstall...)
+ 	}
++	return missing
+ }
+ 
+ // removePackages removes packages that the vendor does not want on the system.
+diff --git a/coa/pkg/tailor/wear.go b/coa/pkg/tailor/wear.go
+index 647baa0..8d7452e 100644
+--- a/coa/pkg/tailor/wear.go
++++ b/coa/pkg/tailor/wear.go
+@@ -5,6 +5,7 @@ import (
+ 	"fmt"
+ 	"os"
+ 	"path/filepath"
++	"strings"
+ )
+ 
+ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+@@ -33,7 +34,8 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+ 	}
+ 
+ 	utils.LogNormal("--- Applying Costume: %s ---", suit.Name)
+-	if err := applySuit(costumeDir, suit); err != nil {
++	failedPackages, err := applySuit(costumeDir, suit)
++	if err != nil {
+ 		return err
+ 	}
+ 
+@@ -44,7 +46,8 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+ 			if accYaml := findYaml(accDir); accYaml != "" {
+ 				if accSuit, err := loadSuit(accYaml); err == nil {
+ 					utils.LogNormal("Accessory: %s", accName)
+-					applySuit(accDir, accSuit)
++					accFailed, _ := applySuit(accDir, accSuit)
++					failedPackages = append(failedPackages, accFailed...)
+ 				}
+ 			}
+ 		}
+@@ -55,6 +58,13 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+ 
+ 	utils.LogNormal("✅ Costume applied successfully!")
+ 
++	if len(failedPackages) > 0 {
++		msg := fmt.Sprintf("⚠️  %d package(s) could not be installed:\n  - %s",
++			len(failedPackages), strings.Join(failedPackages, "\n  - "))
++		utils.LogNormal(utils.ColorYellow + msg + utils.ColorReset)
++		logToFile(msg)
++	}
++
+ 	if suit.Reboot {
+ 		utils.LogNormal(utils.ColorYellow + "This costume recommends a reboot to finish applying all changes." + utils.ColorReset)
+ 	}
+@@ -62,7 +72,12 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+ 	return nil
+ }
+ 
+-func applySuit(dir string, suit *Suit) error {
++// applySuit applies a costume/accessory and returns the list of packages
++// that could not be installed (across packages, packages_no_install_recommends
++// and packages_interactive), so the caller can report them to the user.
++func applySuit(dir string, suit *Suit) ([]string, error) {
++	var failedPackages []string
++
+ 	if suit.Sequence != nil && suit.Sequence.Repositories != nil {
+ 		setupRepositories(suit.Sequence.Repositories, suit.Name)
+ 
+@@ -82,19 +97,19 @@ func applySuit(dir string, suit *Suit) error {
+ 
+ 	if len(suit.Packages) > 0 {
+ 		utils.LogNormal("[%s] Attempting package installation: %v", suit.Name, suit.Packages)
+-		installWithRetries(suit.Packages, 3)
++		failedPackages = append(failedPackages, installWithRetries(suit.Packages, 3)...)
+ 	} else {
+ 		utils.LogNormal("[%s] No packages to install.", suit.Name)
+ 	}
+ 
+ 	if len(suit.PackagesNoRecommends) > 0 {
+ 		utils.LogNormal("[%s] Installing packages without recommends: %v", suit.Name, suit.PackagesNoRecommends)
+-		installNoRecommends(suit.PackagesNoRecommends)
++		failedPackages = append(failedPackages, installNoRecommends(suit.PackagesNoRecommends)...)
+ 	}
+ 
+ 	if len(suit.PackagesInteractive) > 0 {
+ 		utils.LogNormal("[%s] Installing interactive packages (license prompts may appear): %v", suit.Name, suit.PackagesInteractive)
+-		installInteractive(suit.PackagesInteractive)
++		failedPackages = append(failedPackages, installInteractive(suit.PackagesInteractive)...)
+ 	}
+ 
+ 	if len(suit.PackagesRemove) > 0 {
+@@ -129,7 +144,7 @@ func applySuit(dir string, suit *Suit) error {
+ 		}
+ 	}
+ 
+-	return nil
++	return failedPackages, nil
+ }
+ 
+ func copySkelToUser() {

--- a/fix2-chunk-installs.patch
+++ b/fix2-chunk-installs.patch
@@ -1,0 +1,146 @@
+diff --git a/coa/pkg/tailor/wear-logic.go b/coa/pkg/tailor/wear-logic.go
+index 2ff854c..70b18d9 100644
+--- a/coa/pkg/tailor/wear-logic.go
++++ b/coa/pkg/tailor/wear-logic.go
+@@ -84,6 +84,22 @@ func getAvailablePackages() map[string]struct{} {
+ 	return available
+ }
+ 
++// batchSize caps how many packages go into a single apt-get invocation.
++// A single apt-get install with hundreds of packages runs dpkg's trigger
++// processing (initramfs regeneration, DKMS module builds, icon/mime
++// caches, etc.) for the whole batch in one shot at the end, which can be
++// a serious memory/CPU spike on modest VMs and, worse, if the machine
++// dies mid-transaction (OOM, crash) there is no way to know how far it
++// got and no partial progress to resume from on the next run -- the
++// whole multi-hundred-package install has to restart from scratch.
++// Installing in smaller batches keeps each dpkg transaction's trigger
++// processing small, and each successfully completed batch is durably
++// installed on disk, so a crash mid-way only loses the current batch,
++// not everything: re-running `coa wardrobe wear` will see the earlier
++// batches already satisfied (apt-get install on an installed package is
++// a fast no-op) and continue from where it died.
++const batchSize = 20
++
+ func installWithRetries(packages []string, retries int) {
+ 	installPackagesImpl(packages, retries, false)
+ }
+@@ -128,39 +144,57 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 		return
+ 	}
+ 
+-	pkgString := strings.Join(toInstall, " ")
+ 	flags := "-y"
+ 	if noRecommends {
+ 		flags = "-y --no-install-recommends"
+ 	}
+ 
++	totalBatches := (len(toInstall) + batchSize - 1) / batchSize
++	if totalBatches > 1 {
++		logToFile(fmt.Sprintf("Installing %d packages in %d batches of up to %d, so a crash mid-install only loses the current batch...", len(toInstall), totalBatches, batchSize))
++	}
++
++	for start := 0; start < len(toInstall); start += batchSize {
++		end := start + batchSize
++		if end > len(toInstall) {
++			end = len(toInstall)
++		}
++		batch := toInstall[start:end]
++		batchNum := start/batchSize + 1
++
++		if totalBatches > 1 {
++			logToFile(fmt.Sprintf("Batch %d/%d (packages %d-%d of %d): %v", batchNum, totalBatches, start+1, end, len(toInstall), batch))
++		}
++
++		installBatchWithFallback(batch, retries, flags)
++	}
++}
++
++// installBatchWithFallback installs a single batch in bulk, falling back
++// to one-by-one installation within the batch if the bulk call fails, so
++// that one broken package in a batch doesn't take the rest of that batch
++// down with it.
++func installBatchWithFallback(batch []string, retries int, flags string) {
+ 	// readline: accepts low-priority defaults automatically but shows
+ 	// critical prompts (e.g. firmware license agreements) to the user.
+-	// Dpkg::Use-Pty=0: apt normally runs dpkg inside its own internal
+-	// pseudo-terminal so it can both show the output live and log a copy
+-	// to /var/log/apt/term.log. That mirroring has known bugs (Debian
+-	// #765687, #860931) where the copy written to term.log succeeds but
+-	// the live mirror to the real terminal is silently dropped -- the
+-	// user never sees the prompt (or sees it truncated, e.g. "[Más]"
+-	// glued to the next shell prompt) even though stdin/stdout are
+-	// correctly wired to a real tty. Disabling apt's internal pty makes
+-	// dpkg/debconf inherit our own stdio directly instead, which is the
+-	// documented workaround for this class of bug.
+-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
++	// PAGER=cat prevents firmware license scripts from paginating with
++	// 'more' or 'less', which would block unattended installation.
++	pkgString := strings.Join(batch, " ")
++	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
+ 
+ 	for i := 1; i <= retries; i++ {
+ 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
+ 		if err := utils.Exec(cmd); err == nil {
+-			logToFile("✅ Package installation completed.")
++			logToFile("✅ Batch installed.")
+ 			return
+ 		}
+ 
+ 		// Fallback: install one by one so a single broken package
+-		// does not prevent the rest from being installed.
+-		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
++		// does not prevent the rest of the batch from being installed.
++		logToFile("⚠️  Batch install failed. Retrying package by package to isolate failures...")
+ 		var failed []string
+-		for _, pkg := range toInstall {
+-			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
++		for _, pkg := range batch {
++			singleCmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkg)
+ 			if err := utils.Exec(singleCmd); err != nil {
+ 				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
+ 				failed = append(failed, pkg)
+@@ -170,7 +204,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 		if len(failed) > 0 {
+ 			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
+ 		} else {
+-			logToFile("✅ All packages installed successfully (one by one).")
++			logToFile("✅ All packages in batch installed successfully (one by one).")
+ 		}
+ 		return
+ 	}
+@@ -178,8 +212,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 
+ // installInteractive installs packages without suppressing debconf prompts.
+ // Use this for packages that require user interaction (e.g. license acceptance).
+-// Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+-// live prompt from the real terminal (see the comment in installPackagesImpl).
++// PAGER=cat is set to avoid firmware license scripts paginating with 'more'/'less'.
+ func installInteractive(packages []string) {
+ 	if len(packages) == 0 {
+ 		return
+@@ -210,7 +243,7 @@ func installInteractive(packages []string) {
+ 	}
+ 
+ 	pkgString := strings.Join(toInstall, " ")
+-	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
++	cmd := fmt.Sprintf("PAGER=cat apt-get install -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+ 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
+ 	if err := utils.Exec(cmd); err != nil {
+ 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
+@@ -226,13 +259,13 @@ func removePackages(packages []string) {
+ 	}
+ 
+ 	pkgString := strings.Join(packages, " ")
+-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
++	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+ 	logToFile(fmt.Sprintf("Removing packages: %s", pkgString))
+ 	if err := utils.Exec(cmd); err != nil {
+ 		logToFile(fmt.Sprintf("⚠️  Some packages could not be removed (may not be installed): %v", err))
+ 	}
+ 
+-	utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
++	utils.Exec("PAGER=cat DEBIAN_FRONTEND=readline apt-get autoremove -y")
+ }
+ 
+ func printAiPrompt(packages []string) {

--- a/fix3-verify-dpkg.patch
+++ b/fix3-verify-dpkg.patch
@@ -1,0 +1,66 @@
+diff --git a/coa/pkg/tailor/wear-logic.go b/coa/pkg/tailor/wear-logic.go
+index 62d9ce6..8fc8231 100644
+--- a/coa/pkg/tailor/wear-logic.go
++++ b/coa/pkg/tailor/wear-logic.go
+@@ -170,7 +170,18 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
+ 		for _, pkg := range pending {
+ 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
+ 			if err := utils.Exec(singleCmd); err != nil {
+-				stillFailing = append(stillFailing, pkg)
++				// apt-get's exit code alone is not reliable evidence that
++				// THIS package failed: dpkg processes deferred triggers
++				// from unrelated packages during this same invocation, and
++				// a trigger failure poisons the exit code of whatever
++				// install call happened to flush it, even though the
++				// package we actually asked for installed correctly.
++				// Double-check with dpkg before believing the failure.
++				if isPackageInstalled(pkg) {
++					logToFile(fmt.Sprintf("ℹ️  apt-get reported an error installing %s, but dpkg confirms it is installed correctly (likely an unrelated deferred trigger) -- not counting as failed.", pkg))
++				} else {
++					stillFailing = append(stillFailing, pkg)
++				}
+ 			}
+ 		}
+ 		pending = stillFailing
+@@ -188,6 +199,19 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
+ 	return append(missing, pending...)
+ }
+ 
++// isPackageInstalled reports whether dpkg considers pkg to be correctly
++// and fully installed ("install ok installed"), independent of what the
++// most recent apt-get call's exit code said. Used to avoid false-positive
++// failure reports caused by unrelated deferred dpkg triggers poisoning an
++// otherwise-successful package's apt-get exit code.
++func isPackageInstalled(pkg string) bool {
++	out, err := utils.ExecCapture(fmt.Sprintf("dpkg-query -W -f='${Status}' %s 2>/dev/null", pkg))
++	if err != nil {
++		return false
++	}
++	return strings.Contains(out, "install ok installed")
++}
++
+ // installInteractive installs packages without suppressing debconf prompts.
+ // Use this for packages that require user interaction (e.g. license acceptance).
+ // Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+@@ -229,8 +253,19 @@ func installInteractive(packages []string) []string {
+ 	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
+ 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
+ 	if err := utils.Exec(cmd); err != nil {
+-		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
+-		return append(missing, toInstall...)
++		// Don't trust apt-get's exit code blindly: check each package
++		// against dpkg before reporting it as failed (see the comment on
++		// isPackageInstalled for why apt-get's exit code alone can lie).
++		var stillFailing []string
++		for _, pkg := range toInstall {
++			if !isPackageInstalled(pkg) {
++				stillFailing = append(stillFailing, pkg)
++			}
++		}
++		if len(stillFailing) > 0 {
++			logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", stillFailing))
++		}
++		return append(missing, stillFailing...)
+ 	}
+ 	return missing
+ }


### PR DESCRIPTION
**Verify with dpkg before reporting a package as failed**

apt-get install can return a non-zero exit code even when the requested package installed correctly, because dpkg processes deferred triggers from unrelated packages and a trigger failure poisons the exit code of whichever install call happened to flush it. This branch double-checks every apparent failure with `dpkg-query -W -f='${Status}' `before counting it as failed, eliminating false _"could not be installed"_ reports.

**Depends on:** `fix/wardrobe-report-failed-packages.`