### PR TITLE
Fix/wardrobe chunk package installs

### DIFF
--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -84,6 +84,22 @@ func getAvailablePackages() map[string]struct{} {
 	return available
 }
 
+// batchSize caps how many packages go into a single apt-get invocation.
+// A single apt-get install with hundreds of packages runs dpkg's trigger
+// processing (initramfs regeneration, DKMS module builds, icon/mime
+// caches, etc.) for the whole batch in one shot at the end, which can be
+// a serious memory/CPU spike on modest VMs and, worse, if the machine
+// dies mid-transaction (OOM, crash) there is no way to know how far it
+// got and no partial progress to resume from on the next run -- the
+// whole multi-hundred-package install has to restart from scratch.
+// Installing in smaller batches keeps each dpkg transaction's trigger
+// processing small, and each successfully completed batch is durably
+// installed on disk, so a crash mid-way only loses the current batch,
+// not everything: re-running `coa wardrobe wear` will see the earlier
+// batches already satisfied (apt-get install on an installed package is
+// a fast no-op) and continue from where it died.
+const batchSize = 20
+
 func installWithRetries(packages []string, retries int) {
 	installPackagesImpl(packages, retries, false)
 }
@@ -128,39 +144,57 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 		return
 	}
 
-	pkgString := strings.Join(toInstall, " ")
 	flags := "-y"
 	if noRecommends {
 		flags = "-y --no-install-recommends"
 	}
 
+	totalBatches := (len(toInstall) + batchSize - 1) / batchSize
+	if totalBatches > 1 {
+		logToFile(fmt.Sprintf("Installing %d packages in %d batches of up to %d, so a crash mid-install only loses the current batch...", len(toInstall), totalBatches, batchSize))
+	}
+
+	for start := 0; start < len(toInstall); start += batchSize {
+		end := start + batchSize
+		if end > len(toInstall) {
+			end = len(toInstall)
+		}
+		batch := toInstall[start:end]
+		batchNum := start/batchSize + 1
+
+		if totalBatches > 1 {
+			logToFile(fmt.Sprintf("Batch %d/%d (packages %d-%d of %d): %v", batchNum, totalBatches, start+1, end, len(toInstall), batch))
+		}
+
+		installBatchWithFallback(batch, retries, flags)
+	}
+}
+
+// installBatchWithFallback installs a single batch in bulk, falling back
+// to one-by-one installation within the batch if the bulk call fails, so
+// that one broken package in a batch doesn't take the rest of that batch
+// down with it.
+func installBatchWithFallback(batch []string, retries int, flags string) {
 	// readline: accepts low-priority defaults automatically but shows
 	// critical prompts (e.g. firmware license agreements) to the user.
-	// Dpkg::Use-Pty=0: apt normally runs dpkg inside its own internal
-	// pseudo-terminal so it can both show the output live and log a copy
-	// to /var/log/apt/term.log. That mirroring has known bugs (Debian
-	// #765687, #860931) where the copy written to term.log succeeds but
-	// the live mirror to the real terminal is silently dropped -- the
-	// user never sees the prompt (or sees it truncated, e.g. "[Más]"
-	// glued to the next shell prompt) even though stdin/stdout are
-	// correctly wired to a real tty. Disabling apt's internal pty makes
-	// dpkg/debconf inherit our own stdio directly instead, which is the
-	// documented workaround for this class of bug.
-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
+	// PAGER=cat prevents firmware license scripts from paginating with
+	// 'more' or 'less', which would block unattended installation.
+	pkgString := strings.Join(batch, " ")
+	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
 
 	for i := 1; i <= retries; i++ {
 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
 		if err := utils.Exec(cmd); err == nil {
-			logToFile("✅ Package installation completed.")
+			logToFile("✅ Batch installed.")
 			return
 		}
 
 		// Fallback: install one by one so a single broken package
-		// does not prevent the rest from being installed.
-		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
+		// does not prevent the rest of the batch from being installed.
+		logToFile("⚠️  Batch install failed. Retrying package by package to isolate failures...")
 		var failed []string
-		for _, pkg := range toInstall {
-			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
+		for _, pkg := range batch {
+			singleCmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
 				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
 				failed = append(failed, pkg)
@@ -170,7 +204,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 		if len(failed) > 0 {
 			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
 		} else {
-			logToFile("✅ All packages installed successfully (one by one).")
+			logToFile("✅ All packages in batch installed successfully (one by one).")
 		}
 		return
 	}
@@ -178,8 +212,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 // installInteractive installs packages without suppressing debconf prompts.
 // Use this for packages that require user interaction (e.g. license acceptance).
-// Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
-// live prompt from the real terminal (see the comment in installPackagesImpl).
+// PAGER=cat is set to avoid firmware license scripts paginating with 'more'/'less'.
 func installInteractive(packages []string) {
 	if len(packages) == 0 {
 		return
@@ -210,7 +243,7 @@ func installInteractive(packages []string) {
 	}
 
 	pkgString := strings.Join(toInstall, " ")
-	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
+	cmd := fmt.Sprintf("PAGER=cat apt-get install -o Dpkg::Options::='--force-confold' -y %s", pkgString)
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
@@ -226,13 +259,13 @@ func removePackages(packages []string) {
 	}
 
 	pkgString := strings.Join(packages, " ")
-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
+	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -y %s", pkgString)
 	logToFile(fmt.Sprintf("Removing packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some packages could not be removed (may not be installed): %v", err))
 	}
 
-	utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
+	utils.Exec("PAGER=cat DEBIAN_FRONTEND=readline apt-get autoremove -y")
 }
 
 func printAiPrompt(packages []string) {

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -136,9 +136,17 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 	// readline: accepts low-priority defaults automatically but shows
 	// critical prompts (e.g. firmware license agreements) to the user.
-	// PAGER=cat prevents firmware license scripts from paginating with
-	// 'more' or 'less', which would block unattended installation.
-	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
+	// Dpkg::Use-Pty=0: apt normally runs dpkg inside its own internal
+	// pseudo-terminal so it can both show the output live and log a copy
+	// to /var/log/apt/term.log. That mirroring has known bugs (Debian
+	// #765687, #860931) where the copy written to term.log succeeds but
+	// the live mirror to the real terminal is silently dropped -- the
+	// user never sees the prompt (or sees it truncated, e.g. "[Más]"
+	// glued to the next shell prompt) even though stdin/stdout are
+	// correctly wired to a real tty. Disabling apt's internal pty makes
+	// dpkg/debconf inherit our own stdio directly instead, which is the
+	// documented workaround for this class of bug.
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
 
 	for i := 1; i <= retries; i++ {
 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
@@ -152,7 +160,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
 		var failed []string
 		for _, pkg := range toInstall {
-			singleCmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkg)
+			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
 				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
 				failed = append(failed, pkg)
@@ -170,7 +178,8 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 // installInteractive installs packages without suppressing debconf prompts.
 // Use this for packages that require user interaction (e.g. license acceptance).
-// PAGER=cat is set to avoid firmware license scripts paginating with 'more'/'less'.
+// Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+// live prompt from the real terminal (see the comment in installPackagesImpl).
 func installInteractive(packages []string) {
 	if len(packages) == 0 {
 		return
@@ -201,7 +210,7 @@ func installInteractive(packages []string) {
 	}
 
 	pkgString := strings.Join(toInstall, " ")
-	cmd := fmt.Sprintf("PAGER=cat apt-get install -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
@@ -217,13 +226,13 @@ func removePackages(packages []string) {
 	}
 
 	pkgString := strings.Join(packages, " ")
-	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Removing packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some packages could not be removed (may not be installed): %v", err))
 	}
 
-	utils.Exec("PAGER=cat DEBIAN_FRONTEND=readline apt-get autoremove -y")
+	utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
 }
 
 func printAiPrompt(packages []string) {

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -65,6 +65,19 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 func applySuit(dir string, suit *Suit) error {
 	if suit.Sequence != nil && suit.Sequence.Repositories != nil {
 		setupRepositories(suit.Sequence.Repositories, suit.Name)
+
+		// A repository that was just added is invisible to apt until the
+		// package index is refreshed. Without this, every package that
+		// only exists in a repo added above silently fails to be found
+		// by getAvailablePackages() in wear-logic.go and gets skipped
+		// rather than installed -- with no build-time error, only a
+		// line in /var/log/coa-tailor.log. This is what left every
+		// quirinux-* package uninstalled even though the repo's own
+		// .deb installed correctly.
+		utils.LogNormal("[%s] Refreshing package index after repository changes...", suit.Name)
+		if err := utils.Exec("apt-get update"); err != nil {
+			utils.LogNormal("[%s] WARNING: apt-get update failed, newly added repositories may be unusable: %v", suit.Name, err)
+		}
 	}
 
 	if len(suit.Packages) > 0 {


### PR DESCRIPTION
**install wardrobe packages in batches to survive crashes mid-install**

A single apt-get install with hundreds of packages runs dpkg's trigger processing _(initramfs regeneration, DKMS builds, icon/mime caches)_ for the whole batch in one shot: a serious memory/CPU spike on modest VMs, and if the machine dies mid-transaction the entire multi-hundred-package install has to restart from scratch. This branch installs in batches of 20, with a per-batch fallback to one-by-one installation so a single broken package does not take the rest of the batch down. Each completed batch is durably on disk, so re-running wear after a crash resumes instead of restarting.

**Depends on:**` fix/wardrobe-verify-with-dpkg`.