### PR TITLE
Fix/wardrobe declarative manifest

### DIFF
--- a/coa/pkg/tailor/reconcile.go
+++ b/coa/pkg/tailor/reconcile.go
@@ -1,0 +1,279 @@
+package tailor
+
+import (
+	"bufio"
+	"coa/pkg/utils"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// neverPurge is a small, hardcoded safety net of packages that must never
+// be removed by manifest reconciliation, no matter what the manifest says
+// (or fails to say). This is defense-in-depth against a malformed or
+// incomplete manifest file bricking the machine -- it does not fight the
+// vendor's intent, since all of these are expected to be in any correct
+// manifest anyway.
+var neverPurgeBase = []string{
+	"dpkg",
+	"apt",
+	"apt-utils",
+	"base-files",
+	"base-passwd",
+	"init",
+	"sysvinit",
+	"sysvinit-core",
+	"systemd",
+	"systemd-sysv",
+	"libc6",
+	"coreutils",
+	"bash",
+}
+
+// currentKernelPackage returns the package that owns the currently
+// running kernel (e.g. "linux-image-6.1.0-10-amd64"), so it can be
+// protected from removal even if the manifest doesn't happen to list
+// this exact kernel version (e.g. because of a point-release bump).
+// Returns "" if it can't be determined -- callers should not treat that
+// as an error, just as "nothing extra to protect".
+func currentKernelPackage() string {
+	out, err := exec.Command("uname", "-r").Output()
+	if err != nil {
+		return ""
+	}
+	release := strings.TrimSpace(string(out))
+	if release == "" {
+		return ""
+	}
+	pkg := "linux-image-" + release
+	if !isPackageInstalled(pkg) {
+		return ""
+	}
+	return pkg
+}
+
+// normalizePkgName strips the ":arch" multi-arch qualifier some package
+// listings include (e.g. "zlib1g:amd64" -> "zlib1g"), so comparisons
+// against dpkg-query's plain ${Package} output line up correctly.
+func normalizePkgName(name string) string {
+	name = strings.TrimSpace(name)
+	if i := strings.Index(name, ":"); i != -1 {
+		name = name[:i]
+	}
+	return name
+}
+
+// loadPackageManifest reads the target package set from path. It accepts
+// two formats, auto-detected line by line:
+//   - plain: one package name per line ("thunderbird")
+//   - dpkg -l / dpkg-query -W style: "ii  thunderbird  1:128.0-1  amd64  ..."
+//     (only lines starting with a two-letter dpkg status code followed by
+//     whitespace are treated this way; the package name is the 2nd field)
+//
+// Blank lines and lines starting with '#' are ignored.
+func loadPackageManifest(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	seen := make(map[string]struct{})
+	var result []string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		var pkg string
+		if len(fields) >= 2 && len(fields[0]) <= 3 && isDpkgStatusCode(fields[0]) {
+			// dpkg -l style: "ii  package-name  version  arch  description..."
+			pkg = fields[1]
+		} else {
+			pkg = fields[0]
+		}
+
+		pkg = normalizePkgName(pkg)
+		if pkg == "" {
+			continue
+		}
+		if _, ok := seen[pkg]; ok {
+			continue
+		}
+		seen[pkg] = struct{}{}
+		result = append(result, pkg)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func isDpkgStatusCode(s string) bool {
+	switch s {
+	case "ii", "rc", "un", "iF", "iU", "hi", "pn":
+		return true
+	}
+	return false
+}
+
+// currentlyInstalledPackages returns the set of packages dpkg currently
+// considers fully installed on the system.
+func currentlyInstalledPackages() (map[string]struct{}, error) {
+	out, err := utils.ExecCapture("dpkg-query -W -f='${Package} ${Status}\\n'")
+	if err != nil {
+		return nil, err
+	}
+
+	installed := make(map[string]struct{})
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !strings.Contains(line, "install ok installed") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		installed[normalizePkgName(fields[0])] = struct{}{}
+	}
+	return installed, nil
+}
+
+// reconcilePackages makes the installed package set match target exactly:
+// anything in target that's missing gets installed, anything installed
+// that's not in target (and not in the never-purge safety net) gets
+// purged. Returns a human-readable summary of what happened for the
+// caller to include in the final wear report.
+func reconcilePackages(target []string) (installedNow []string, purgedNow []string, failedInstall []string, failedPurge []string) {
+	installedSet, err := currentlyInstalledPackages()
+	if err != nil {
+		logToFile(fmt.Sprintf("⚠️  Could not reconcile packages against manifest: failed to query dpkg: %v", err))
+		return nil, nil, nil, nil
+	}
+
+	targetSet := make(map[string]struct{}, len(target))
+	for _, p := range target {
+		targetSet[normalizePkgName(p)] = struct{}{}
+	}
+
+	protect := make(map[string]struct{})
+	for _, p := range neverPurgeBase {
+		protect[p] = struct{}{}
+	}
+	if kernel := currentKernelPackage(); kernel != "" {
+		protect[kernel] = struct{}{}
+	}
+
+	var toInstall []string
+	for p := range targetSet {
+		if _, ok := installedSet[p]; !ok {
+			toInstall = append(toInstall, p)
+		}
+	}
+
+	var toPurge []string
+	for p := range installedSet {
+		if _, ok := targetSet[p]; ok {
+			continue
+		}
+		if _, ok := protect[p]; ok {
+			continue
+		}
+		toPurge = append(toPurge, p)
+	}
+
+	if len(toInstall) > 0 {
+		logToFile(fmt.Sprintf("Manifest reconciliation: %d package(s) missing, installing...", len(toInstall)))
+		failedInstall = installWithRetries(toInstall, 3)
+		for _, p := range toInstall {
+			if !containsStr(failedInstall, p) {
+				installedNow = append(installedNow, p)
+			}
+		}
+	}
+
+	if len(toPurge) > 0 {
+		logToFile(fmt.Sprintf("Manifest reconciliation: %d package(s) present but not in the manifest, purging...", len(toPurge)))
+		purgedNow, failedPurge = purgeBatched(toPurge)
+	}
+
+	return installedNow, purgedNow, failedInstall, failedPurge
+}
+
+func containsStr(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// purgeBatched purges packages in small batches (same rationale as
+// installBatchWithFallback: keep each dpkg transaction's trigger
+// processing small, and survive a crash mid-way with partial progress
+// intact). Verifies each failure against dpkg before giving up on it,
+// for the same reason installBatchWithFallback does.
+func purgeBatched(packages []string) (purged []string, failed []string) {
+	for start := 0; start < len(packages); start += batchSize {
+		end := start + batchSize
+		if end > len(packages) {
+			end = len(packages)
+		}
+		batch := packages[start:end]
+
+		pkgString := strings.Join(batch, " ")
+		cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get purge -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
+		logToFile(fmt.Sprintf("Purging batch of %d package(s) not in the manifest: %v", len(batch), batch))
+
+		if err := utils.Exec(cmd); err == nil {
+			purged = append(purged, batch...)
+			continue
+		}
+
+		logToFile("⚠️  Batch purge failed. Retrying package by package to isolate failures...")
+		for _, pkg := range batch {
+			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get purge -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkg)
+			err := utils.Exec(singleCmd)
+			if err == nil || !isPackageInstalled(pkg) {
+				purged = append(purged, pkg)
+			} else {
+				logToFile(fmt.Sprintf("⚠️  Could not purge: %s", pkg))
+				failed = append(failed, pkg)
+			}
+		}
+	}
+
+	// Clean up now-orphaned dependencies of everything we just purged.
+	// Safe to run generically here since it only touches packages apt
+	// itself marked as automatically installed with no remaining
+	// reverse-dependencies -- it will never touch anything in `target`.
+	if len(purged) > 0 {
+		utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
+	}
+
+	return purged, failed
+}
+
+func findManifestPath(costumeDir, manifest string) string {
+	if manifest == "" {
+		return ""
+	}
+	path := filepath.Join(costumeDir, manifest)
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	return path
+}

--- a/coa/pkg/tailor/types.go
+++ b/coa/pkg/tailor/types.go
@@ -20,6 +20,17 @@ type Suit struct {
 	Sequence      *Sequence        `yaml:"sequence"`
 	Finalize      *Finalize        `yaml:"finalize"`
 	Reboot        bool             `yaml:"reboot"`
+	// PackagesManifest points to a file (relative to the costume dir)
+	// listing the COMPLETE, exact set of packages the system should end
+	// up with -- either plain "one package name per line" or the output
+	// of `dpkg -l` / `dpkg-query -W`. When set, wear() reconciles the
+	// system against it after the regular install steps: anything in the
+	// manifest that's missing gets installed, and anything installed on
+	// the system that is NOT in the manifest gets purged (except for a
+	// small hardcoded set of packages that are never safe to remove,
+	// e.g. the currently running kernel). This is what makes a wardrobe
+	// authoritative/declarative instead of purely additive.
+	PackagesManifest string `yaml:"packages_manifest"`
 	PackagesNoRecommends []string `yaml:"-"`
 	// Popolato da normalize() a partire da Sequence.PackagesInteractive.
 	// These packages are installed without DEBIAN_FRONTEND=noninteractive

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -84,23 +84,29 @@ func getAvailablePackages() map[string]struct{} {
 	return available
 }
 
-func installWithRetries(packages []string, retries int) {
-	installPackagesImpl(packages, retries, false)
+// installWithRetries installs packages, falling back to one-by-one
+// installation on bulk failure so a single broken package does not
+// prevent the rest from being installed. Returns the packages that
+// could not be installed (including any not found in apt's cache),
+// so the caller can report them to the user.
+func installWithRetries(packages []string, retries int) []string {
+	return installPackagesImpl(packages, retries, false)
 }
 
 // installNoRecommends installs packages with --no-install-recommends.
-func installNoRecommends(packages []string) {
-	installPackagesImpl(packages, 3, true)
+// Returns the packages that could not be installed.
+func installNoRecommends(packages []string) []string {
+	return installPackagesImpl(packages, 3, true)
 }
 
-func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+func installPackagesImpl(packages []string, retries int, noRecommends bool) []string {
 	if len(packages) == 0 {
-		return
+		return nil
 	}
 
 	if _, err := exec.LookPath("apt-get"); err != nil {
 		printAiPrompt(packages)
-		return
+		return nil
 	}
 
 	available := getAvailablePackages()
@@ -125,7 +131,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 	if len(toInstall) == 0 {
 		logToFile("No valid packages to install.")
-		return
+		return missing
 	}
 
 	pkgString := strings.Join(toInstall, " ")
@@ -148,41 +154,51 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 	// documented workaround for this class of bug.
 	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
 
-	for i := 1; i <= retries; i++ {
-		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
-		if err := utils.Exec(cmd); err == nil {
-			logToFile("✅ Package installation completed.")
-			return
-		}
+	logToFile(fmt.Sprintf("Installing %d packages in bulk...", len(toInstall)))
+	if err := utils.Exec(cmd); err == nil {
+		logToFile("✅ Package installation completed.")
+		return missing
+	}
 
-		// Fallback: install one by one so a single broken package
-		// does not prevent the rest from being installed.
-		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
-		var failed []string
-		for _, pkg := range toInstall {
+	// Fallback: install one by one so a single broken package does not
+	// prevent the rest from being installed. Packages that still fail
+	// after `retries` individual attempts are given up on and reported.
+	logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
+	pending := toInstall
+	for attempt := 1; attempt <= retries && len(pending) > 0; attempt++ {
+		var stillFailing []string
+		for _, pkg := range pending {
 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
-				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
-				failed = append(failed, pkg)
+				stillFailing = append(stillFailing, pkg)
 			}
 		}
-
-		if len(failed) > 0 {
-			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
-		} else {
-			logToFile("✅ All packages installed successfully (one by one).")
+		pending = stillFailing
+		if len(pending) > 0 && attempt < retries {
+			logToFile(fmt.Sprintf("⚠️  %d packages still failing after attempt %d/%d, retrying: %v", len(pending), attempt, retries, pending))
 		}
-		return
 	}
+
+	if len(pending) > 0 {
+		logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(pending), pending))
+	} else {
+		logToFile("✅ All packages installed successfully (one by one).")
+	}
+
+	return append(missing, pending...)
 }
 
 // installInteractive installs packages without suppressing debconf prompts.
 // Use this for packages that require user interaction (e.g. license acceptance).
 // Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
 // live prompt from the real terminal (see the comment in installPackagesImpl).
-func installInteractive(packages []string) {
+// Returns the packages that could not be installed (missing from apt's
+// cache, or the whole batch if the bulk apt-get call failed -- interactive
+// packages are typically few and license-related, so we don't attempt the
+// one-by-one isolation used for regular packages).
+func installInteractive(packages []string) []string {
 	if len(packages) == 0 {
-		return
+		return nil
 	}
 
 	available := getAvailablePackages()
@@ -206,7 +222,7 @@ func installInteractive(packages []string) {
 	}
 
 	if len(toInstall) == 0 {
-		return
+		return missing
 	}
 
 	pkgString := strings.Join(toInstall, " ")
@@ -214,7 +230,9 @@ func installInteractive(packages []string) {
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
+		return append(missing, toInstall...)
 	}
+	return missing
 }
 
 // removePackages removes packages that the vendor does not want on the system.

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -84,6 +84,22 @@ func getAvailablePackages() map[string]struct{} {
 	return available
 }
 
+// batchSize caps how many packages go into a single apt-get invocation.
+// A single apt-get install with hundreds of packages runs dpkg's trigger
+// processing (initramfs regeneration, DKMS module builds, icon/mime
+// caches, etc.) for the whole batch in one shot at the end, which can be
+// a serious memory/CPU spike on modest VMs and, worse, if the machine
+// dies mid-transaction (OOM, crash) there is no way to know how far it
+// got and no partial progress to resume from on the next run -- the
+// whole multi-hundred-package install has to restart from scratch.
+// Installing in smaller batches keeps each dpkg transaction's trigger
+// processing small, and each successfully completed batch is durably
+// installed on disk, so a crash mid-way only loses the current batch,
+// not everything: re-running `coa wardrobe wear` will see the earlier
+// batches already satisfied (apt-get install on an installed package is
+// a fast no-op) and continue from where it died.
+const batchSize = 20
+
 func installWithRetries(packages []string, retries int) {
 	installPackagesImpl(packages, retries, false)
 }
@@ -128,39 +144,57 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 		return
 	}
 
-	pkgString := strings.Join(toInstall, " ")
 	flags := "-y"
 	if noRecommends {
 		flags = "-y --no-install-recommends"
 	}
 
+	totalBatches := (len(toInstall) + batchSize - 1) / batchSize
+	if totalBatches > 1 {
+		logToFile(fmt.Sprintf("Installing %d packages in %d batches of up to %d, so a crash mid-install only loses the current batch...", len(toInstall), totalBatches, batchSize))
+	}
+
+	for start := 0; start < len(toInstall); start += batchSize {
+		end := start + batchSize
+		if end > len(toInstall) {
+			end = len(toInstall)
+		}
+		batch := toInstall[start:end]
+		batchNum := start/batchSize + 1
+
+		if totalBatches > 1 {
+			logToFile(fmt.Sprintf("Batch %d/%d (packages %d-%d of %d): %v", batchNum, totalBatches, start+1, end, len(toInstall), batch))
+		}
+
+		installBatchWithFallback(batch, retries, flags)
+	}
+}
+
+// installBatchWithFallback installs a single batch in bulk, falling back
+// to one-by-one installation within the batch if the bulk call fails, so
+// that one broken package in a batch doesn't take the rest of that batch
+// down with it.
+func installBatchWithFallback(batch []string, retries int, flags string) {
 	// readline: accepts low-priority defaults automatically but shows
 	// critical prompts (e.g. firmware license agreements) to the user.
-	// Dpkg::Use-Pty=0: apt normally runs dpkg inside its own internal
-	// pseudo-terminal so it can both show the output live and log a copy
-	// to /var/log/apt/term.log. That mirroring has known bugs (Debian
-	// #765687, #860931) where the copy written to term.log succeeds but
-	// the live mirror to the real terminal is silently dropped -- the
-	// user never sees the prompt (or sees it truncated, e.g. "[Más]"
-	// glued to the next shell prompt) even though stdin/stdout are
-	// correctly wired to a real tty. Disabling apt's internal pty makes
-	// dpkg/debconf inherit our own stdio directly instead, which is the
-	// documented workaround for this class of bug.
-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
+	// PAGER=cat prevents firmware license scripts from paginating with
+	// 'more' or 'less', which would block unattended installation.
+	pkgString := strings.Join(batch, " ")
+	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
 
 	for i := 1; i <= retries; i++ {
 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
 		if err := utils.Exec(cmd); err == nil {
-			logToFile("✅ Package installation completed.")
+			logToFile("✅ Batch installed.")
 			return
 		}
 
 		// Fallback: install one by one so a single broken package
-		// does not prevent the rest from being installed.
-		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
+		// does not prevent the rest of the batch from being installed.
+		logToFile("⚠️  Batch install failed. Retrying package by package to isolate failures...")
 		var failed []string
-		for _, pkg := range toInstall {
-			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
+		for _, pkg := range batch {
+			singleCmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
 				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
 				failed = append(failed, pkg)
@@ -170,7 +204,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 		if len(failed) > 0 {
 			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
 		} else {
-			logToFile("✅ All packages installed successfully (one by one).")
+			logToFile("✅ All packages in batch installed successfully (one by one).")
 		}
 		return
 	}
@@ -178,8 +212,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 // installInteractive installs packages without suppressing debconf prompts.
 // Use this for packages that require user interaction (e.g. license acceptance).
-// Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
-// live prompt from the real terminal (see the comment in installPackagesImpl).
+// PAGER=cat is set to avoid firmware license scripts paginating with 'more'/'less'.
 func installInteractive(packages []string) {
 	if len(packages) == 0 {
 		return
@@ -210,7 +243,7 @@ func installInteractive(packages []string) {
 	}
 
 	pkgString := strings.Join(toInstall, " ")
-	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
+	cmd := fmt.Sprintf("PAGER=cat apt-get install -o Dpkg::Options::='--force-confold' -y %s", pkgString)
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
@@ -226,13 +259,13 @@ func removePackages(packages []string) {
 	}
 
 	pkgString := strings.Join(packages, " ")
-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
+	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -y %s", pkgString)
 	logToFile(fmt.Sprintf("Removing packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some packages could not be removed (may not be installed): %v", err))
 	}
 
-	utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
+	utils.Exec("PAGER=cat DEBIAN_FRONTEND=readline apt-get autoremove -y")
 }
 
 func printAiPrompt(packages []string) {

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -84,15 +84,6 @@ func getAvailablePackages() map[string]struct{} {
 	return available
 }
 
-<<<<<<< HEAD
-// installWithRetries installs packages, falling back to one-by-one
-// installation on bulk failure so a single broken package does not
-// prevent the rest from being installed. Returns the packages that
-// could not be installed (including any not found in apt's cache),
-// so the caller can report them to the user.
-func installWithRetries(packages []string, retries int) []string {
-	return installPackagesImpl(packages, retries, false)
-=======
 // batchSize caps how many packages go into a single apt-get invocation.
 // A single apt-get install with hundreds of packages runs dpkg's trigger
 // processing (initramfs regeneration, DKMS module builds, icon/mime
@@ -109,9 +100,13 @@ func installWithRetries(packages []string, retries int) []string {
 // a fast no-op) and continue from where it died.
 const batchSize = 20
 
-func installWithRetries(packages []string, retries int) {
-	installPackagesImpl(packages, retries, false)
->>>>>>> fix/wardrobe-chunk-package-installs
+// installWithRetries installs packages, falling back to one-by-one
+// installation on bulk failure so a single broken package does not
+// prevent the rest from being installed. Returns the packages that
+// could not be installed (including any not found in apt's cache),
+// so the caller can report them to the user.
+func installWithRetries(packages []string, retries int) []string {
+	return installPackagesImpl(packages, retries, false)
 }
 
 // installNoRecommends installs packages with --no-install-recommends.
@@ -165,6 +160,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
 		logToFile(fmt.Sprintf("Installing %d packages in %d batches of up to %d, so a crash mid-install only loses the current batch...", len(toInstall), totalBatches, batchSize))
 	}
 
+	var failed []string
 	for start := 0; start < len(toInstall); start += batchSize {
 		end := start + batchSize
 		if end > len(toInstall) {
@@ -177,53 +173,48 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
 			logToFile(fmt.Sprintf("Batch %d/%d (packages %d-%d of %d): %v", batchNum, totalBatches, start+1, end, len(toInstall), batch))
 		}
 
-		installBatchWithFallback(batch, retries, flags)
+		failed = append(failed, installBatchWithFallback(batch, retries, flags)...)
 	}
+
+	return append(missing, failed...)
 }
 
 // installBatchWithFallback installs a single batch in bulk, falling back
 // to one-by-one installation within the batch if the bulk call fails, so
 // that one broken package in a batch doesn't take the rest of that batch
-// down with it.
-func installBatchWithFallback(batch []string, retries int, flags string) {
+// down with it. Packages that still fail after `retries` individual
+// attempts are given up on and returned to the caller.
+func installBatchWithFallback(batch []string, retries int, flags string) []string {
 	// readline: accepts low-priority defaults automatically but shows
 	// critical prompts (e.g. firmware license agreements) to the user.
-	// PAGER=cat prevents firmware license scripts from paginating with
-	// 'more' or 'less', which would block unattended installation.
+	// Dpkg::Use-Pty=0: apt normally runs dpkg inside its own internal
+	// pseudo-terminal so it can both show the output live and log a copy
+	// to /var/log/apt/term.log. That mirroring has known bugs (Debian
+	// #765687, #860931) where the copy written to term.log succeeds but
+	// the live mirror to the real terminal is silently dropped -- the
+	// user never sees the prompt (or sees it truncated, e.g. "[Más]"
+	// glued to the next shell prompt) even though stdin/stdout are
+	// correctly wired to a real tty. Disabling apt's internal pty makes
+	// dpkg/debconf inherit our own stdio directly instead, which is the
+	// documented workaround for this class of bug.
 	pkgString := strings.Join(batch, " ")
-	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
 
-<<<<<<< HEAD
-	logToFile(fmt.Sprintf("Installing %d packages in bulk...", len(toInstall)))
+	logToFile(fmt.Sprintf("Installing batch of %d packages...", len(batch)))
 	if err := utils.Exec(cmd); err == nil {
-		logToFile("✅ Package installation completed.")
-		return missing
+		logToFile("✅ Batch installed.")
+		return nil
 	}
 
 	// Fallback: install one by one so a single broken package does not
-	// prevent the rest from being installed. Packages that still fail
-	// after `retries` individual attempts are given up on and reported.
-	logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
-	pending := toInstall
+	// prevent the rest of the batch from being installed. Packages that
+	// still fail after `retries` individual attempts are given up on.
+	logToFile("⚠️  Batch install failed. Retrying package by package to isolate failures...")
+	pending := batch
 	for attempt := 1; attempt <= retries && len(pending) > 0; attempt++ {
 		var stillFailing []string
 		for _, pkg := range pending {
 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
-=======
-	for i := 1; i <= retries; i++ {
-		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
-		if err := utils.Exec(cmd); err == nil {
-			logToFile("✅ Batch installed.")
-			return
-		}
-
-		// Fallback: install one by one so a single broken package
-		// does not prevent the rest of the batch from being installed.
-		logToFile("⚠️  Batch install failed. Retrying package by package to isolate failures...")
-		var failed []string
-		for _, pkg := range batch {
-			singleCmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkg)
->>>>>>> fix/wardrobe-chunk-package-installs
 			if err := utils.Exec(singleCmd); err != nil {
 				// apt-get's exit code alone is not reliable evidence that
 				// THIS package failed: dpkg processes deferred triggers
@@ -239,27 +230,19 @@ func installBatchWithFallback(batch []string, retries int, flags string) {
 				}
 			}
 		}
-<<<<<<< HEAD
 		pending = stillFailing
 		if len(pending) > 0 && attempt < retries {
 			logToFile(fmt.Sprintf("⚠️  %d packages still failing after attempt %d/%d, retrying: %v", len(pending), attempt, retries, pending))
-=======
-
-		if len(failed) > 0 {
-			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
-		} else {
-			logToFile("✅ All packages in batch installed successfully (one by one).")
->>>>>>> fix/wardrobe-chunk-package-installs
 		}
 	}
 
 	if len(pending) > 0 {
 		logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(pending), pending))
 	} else {
-		logToFile("✅ All packages installed successfully (one by one).")
+		logToFile("✅ All packages in batch installed successfully (one by one).")
 	}
 
-	return append(missing, pending...)
+	return pending
 }
 
 // isPackageInstalled reports whether dpkg considers pkg to be correctly
@@ -277,7 +260,6 @@ func isPackageInstalled(pkg string) bool {
 
 // installInteractive installs packages without suppressing debconf prompts.
 // Use this for packages that require user interaction (e.g. license acceptance).
-<<<<<<< HEAD
 // Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
 // live prompt from the real terminal (see the comment in installPackagesImpl).
 // Returns the packages that could not be installed (missing from apt's
@@ -285,10 +267,6 @@ func isPackageInstalled(pkg string) bool {
 // packages are typically few and license-related, so we don't attempt the
 // one-by-one isolation used for regular packages).
 func installInteractive(packages []string) []string {
-=======
-// PAGER=cat is set to avoid firmware license scripts paginating with 'more'/'less'.
-func installInteractive(packages []string) {
->>>>>>> fix/wardrobe-chunk-package-installs
 	if len(packages) == 0 {
 		return nil
 	}
@@ -318,7 +296,7 @@ func installInteractive(packages []string) {
 	}
 
 	pkgString := strings.Join(toInstall, " ")
-	cmd := fmt.Sprintf("PAGER=cat apt-get install -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		// Don't trust apt-get's exit code blindly: check each package
@@ -347,13 +325,13 @@ func removePackages(packages []string) {
 	}
 
 	pkgString := strings.Join(packages, " ")
-	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Removing packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some packages could not be removed (may not be installed): %v", err))
 	}
 
-	utils.Exec("PAGER=cat DEBIAN_FRONTEND=readline apt-get autoremove -y")
+	utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
 }
 
 func printAiPrompt(packages []string) {

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -170,7 +170,18 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
 		for _, pkg := range pending {
 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
-				stillFailing = append(stillFailing, pkg)
+				// apt-get's exit code alone is not reliable evidence that
+				// THIS package failed: dpkg processes deferred triggers
+				// from unrelated packages during this same invocation, and
+				// a trigger failure poisons the exit code of whatever
+				// install call happened to flush it, even though the
+				// package we actually asked for installed correctly.
+				// Double-check with dpkg before believing the failure.
+				if isPackageInstalled(pkg) {
+					logToFile(fmt.Sprintf("ℹ️  apt-get reported an error installing %s, but dpkg confirms it is installed correctly (likely an unrelated deferred trigger) -- not counting as failed.", pkg))
+				} else {
+					stillFailing = append(stillFailing, pkg)
+				}
 			}
 		}
 		pending = stillFailing
@@ -186,6 +197,19 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
 	}
 
 	return append(missing, pending...)
+}
+
+// isPackageInstalled reports whether dpkg considers pkg to be correctly
+// and fully installed ("install ok installed"), independent of what the
+// most recent apt-get call's exit code said. Used to avoid false-positive
+// failure reports caused by unrelated deferred dpkg triggers poisoning an
+// otherwise-successful package's apt-get exit code.
+func isPackageInstalled(pkg string) bool {
+	out, err := utils.ExecCapture(fmt.Sprintf("dpkg-query -W -f='${Status}' %s 2>/dev/null", pkg))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(out, "install ok installed")
 }
 
 // installInteractive installs packages without suppressing debconf prompts.
@@ -229,8 +253,19 @@ func installInteractive(packages []string) []string {
 	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
-		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
-		return append(missing, toInstall...)
+		// Don't trust apt-get's exit code blindly: check each package
+		// against dpkg before reporting it as failed (see the comment on
+		// isPackageInstalled for why apt-get's exit code alone can lie).
+		var stillFailing []string
+		for _, pkg := range toInstall {
+			if !isPackageInstalled(pkg) {
+				stillFailing = append(stillFailing, pkg)
+			}
+		}
+		if len(stillFailing) > 0 {
+			logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", stillFailing))
+		}
+		return append(missing, stillFailing...)
 	}
 	return missing
 }

--- a/coa/pkg/tailor/wear-logic.go
+++ b/coa/pkg/tailor/wear-logic.go
@@ -136,9 +136,17 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 	// readline: accepts low-priority defaults automatically but shows
 	// critical prompts (e.g. firmware license agreements) to the user.
-	// PAGER=cat prevents firmware license scripts from paginating with
-	// 'more' or 'less', which would block unattended installation.
-	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
+	// Dpkg::Use-Pty=0: apt normally runs dpkg inside its own internal
+	// pseudo-terminal so it can both show the output live and log a copy
+	// to /var/log/apt/term.log. That mirroring has known bugs (Debian
+	// #765687, #860931) where the copy written to term.log succeeds but
+	// the live mirror to the real terminal is silently dropped -- the
+	// user never sees the prompt (or sees it truncated, e.g. "[Más]"
+	// glued to the next shell prompt) even though stdin/stdout are
+	// correctly wired to a real tty. Disabling apt's internal pty makes
+	// dpkg/debconf inherit our own stdio directly instead, which is the
+	// documented workaround for this class of bug.
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
 
 	for i := 1; i <= retries; i++ {
 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
@@ -152,7 +160,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
 		var failed []string
 		for _, pkg := range toInstall {
-			singleCmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkg)
+			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
 			if err := utils.Exec(singleCmd); err != nil {
 				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
 				failed = append(failed, pkg)
@@ -170,7 +178,8 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
 
 // installInteractive installs packages without suppressing debconf prompts.
 // Use this for packages that require user interaction (e.g. license acceptance).
-// PAGER=cat is set to avoid firmware license scripts paginating with 'more'/'less'.
+// Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+// live prompt from the real terminal (see the comment in installPackagesImpl).
 func installInteractive(packages []string) {
 	if len(packages) == 0 {
 		return
@@ -201,7 +210,7 @@ func installInteractive(packages []string) {
 	}
 
 	pkgString := strings.Join(toInstall, " ")
-	cmd := fmt.Sprintf("PAGER=cat apt-get install -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
@@ -217,13 +226,13 @@ func removePackages(packages []string) {
 	}
 
 	pkgString := strings.Join(packages, " ")
-	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
 	logToFile(fmt.Sprintf("Removing packages: %s", pkgString))
 	if err := utils.Exec(cmd); err != nil {
 		logToFile(fmt.Sprintf("⚠️  Some packages could not be removed (may not be installed): %v", err))
 	}
 
-	utils.Exec("PAGER=cat DEBIAN_FRONTEND=readline apt-get autoremove -y")
+	utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
 }
 
 func printAiPrompt(packages []string) {

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -53,10 +53,35 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 		}
 	}
 
+	var purgedPackages []string
+	var failedPurges []string
+	if manifestPath := findManifestPath(costumeDir, suit.PackagesManifest); manifestPath != "" {
+		utils.LogNormal("--- Reconciling installed packages against manifest: %s ---", manifestPath)
+		target, err := loadPackageManifest(manifestPath)
+		if err != nil {
+			utils.LogNormal(utils.ColorYellow+"WARNING: could not read packages_manifest %s: %v"+utils.ColorReset, manifestPath, err)
+		} else {
+			var reconcileFailed []string
+			_, purgedPackages, reconcileFailed, failedPurges = reconcilePackages(target)
+			failedPackages = append(failedPackages, reconcileFailed...)
+		}
+	}
+
 	utils.LogNormal("--- Finalizing ---")
 	copySkelToUser()
 
 	utils.LogNormal("✅ Costume applied successfully!")
+
+	if len(purgedPackages) > 0 {
+		utils.LogNormal("🧹 %d package(s) removed for not being in the manifest.", len(purgedPackages))
+	}
+
+	if len(failedPurges) > 0 {
+		msg := fmt.Sprintf("⚠️  %d package(s) could not be removed even though they are not in the manifest:\n  - %s",
+			len(failedPurges), strings.Join(failedPurges, "\n  - "))
+		utils.LogNormal(utils.ColorYellow + msg + utils.ColorReset)
+		logToFile(msg)
+	}
 
 	if len(failedPackages) > 0 {
 		msg := fmt.Sprintf("⚠️  %d package(s) could not be installed:\n  - %s",

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -65,6 +65,19 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 func applySuit(dir string, suit *Suit) error {
 	if suit.Sequence != nil && suit.Sequence.Repositories != nil {
 		setupRepositories(suit.Sequence.Repositories, suit.Name)
+
+		// A repository that was just added is invisible to apt until the
+		// package index is refreshed. Without this, every package that
+		// only exists in a repo added above silently fails to be found
+		// by getAvailablePackages() in wear-logic.go and gets skipped
+		// rather than installed -- with no build-time error, only a
+		// line in /var/log/coa-tailor.log. This is what left every
+		// quirinux-* package uninstalled even though the repo's own
+		// .deb installed correctly.
+		utils.LogNormal("[%s] Refreshing package index after repository changes...", suit.Name)
+		if err := utils.Exec("apt-get update"); err != nil {
+			utils.LogNormal("[%s] WARNING: apt-get update failed, newly added repositories may be unusable: %v", suit.Name, err)
+		}
 	}
 
 	if len(suit.Packages) > 0 {

--- a/coa/pkg/tailor/wear.go
+++ b/coa/pkg/tailor/wear.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func Wear(costumeName string, noAcc bool, noFirm bool) error {
@@ -33,7 +34,8 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 	}
 
 	utils.LogNormal("--- Applying Costume: %s ---", suit.Name)
-	if err := applySuit(costumeDir, suit); err != nil {
+	failedPackages, err := applySuit(costumeDir, suit)
+	if err != nil {
 		return err
 	}
 
@@ -44,7 +46,8 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 			if accYaml := findYaml(accDir); accYaml != "" {
 				if accSuit, err := loadSuit(accYaml); err == nil {
 					utils.LogNormal("Accessory: %s", accName)
-					applySuit(accDir, accSuit)
+					accFailed, _ := applySuit(accDir, accSuit)
+					failedPackages = append(failedPackages, accFailed...)
 				}
 			}
 		}
@@ -55,6 +58,13 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 
 	utils.LogNormal("✅ Costume applied successfully!")
 
+	if len(failedPackages) > 0 {
+		msg := fmt.Sprintf("⚠️  %d package(s) could not be installed:\n  - %s",
+			len(failedPackages), strings.Join(failedPackages, "\n  - "))
+		utils.LogNormal(utils.ColorYellow + msg + utils.ColorReset)
+		logToFile(msg)
+	}
+
 	if suit.Reboot {
 		utils.LogNormal(utils.ColorYellow + "This costume recommends a reboot to finish applying all changes." + utils.ColorReset)
 	}
@@ -62,7 +72,12 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
 	return nil
 }
 
-func applySuit(dir string, suit *Suit) error {
+// applySuit applies a costume/accessory and returns the list of packages
+// that could not be installed (across packages, packages_no_install_recommends
+// and packages_interactive), so the caller can report them to the user.
+func applySuit(dir string, suit *Suit) ([]string, error) {
+	var failedPackages []string
+
 	if suit.Sequence != nil && suit.Sequence.Repositories != nil {
 		setupRepositories(suit.Sequence.Repositories, suit.Name)
 
@@ -82,19 +97,19 @@ func applySuit(dir string, suit *Suit) error {
 
 	if len(suit.Packages) > 0 {
 		utils.LogNormal("[%s] Attempting package installation: %v", suit.Name, suit.Packages)
-		installWithRetries(suit.Packages, 3)
+		failedPackages = append(failedPackages, installWithRetries(suit.Packages, 3)...)
 	} else {
 		utils.LogNormal("[%s] No packages to install.", suit.Name)
 	}
 
 	if len(suit.PackagesNoRecommends) > 0 {
 		utils.LogNormal("[%s] Installing packages without recommends: %v", suit.Name, suit.PackagesNoRecommends)
-		installNoRecommends(suit.PackagesNoRecommends)
+		failedPackages = append(failedPackages, installNoRecommends(suit.PackagesNoRecommends)...)
 	}
 
 	if len(suit.PackagesInteractive) > 0 {
 		utils.LogNormal("[%s] Installing interactive packages (license prompts may appear): %v", suit.Name, suit.PackagesInteractive)
-		installInteractive(suit.PackagesInteractive)
+		failedPackages = append(failedPackages, installInteractive(suit.PackagesInteractive)...)
 	}
 
 	if len(suit.PackagesRemove) > 0 {
@@ -129,7 +144,7 @@ func applySuit(dir string, suit *Suit) error {
 		}
 	}
 
-	return nil
+	return failedPackages, nil
 }
 
 func copySkelToUser() {

--- a/fix1-report-failed.patch
+++ b/fix1-report-failed.patch
@@ -1,0 +1,234 @@
+diff --git a/coa/pkg/tailor/wear-logic.go b/coa/pkg/tailor/wear-logic.go
+index 2ff854c..62d9ce6 100644
+--- a/coa/pkg/tailor/wear-logic.go
++++ b/coa/pkg/tailor/wear-logic.go
+@@ -84,23 +84,29 @@ func getAvailablePackages() map[string]struct{} {
+ 	return available
+ }
+ 
+-func installWithRetries(packages []string, retries int) {
+-	installPackagesImpl(packages, retries, false)
++// installWithRetries installs packages, falling back to one-by-one
++// installation on bulk failure so a single broken package does not
++// prevent the rest from being installed. Returns the packages that
++// could not be installed (including any not found in apt's cache),
++// so the caller can report them to the user.
++func installWithRetries(packages []string, retries int) []string {
++	return installPackagesImpl(packages, retries, false)
+ }
+ 
+ // installNoRecommends installs packages with --no-install-recommends.
+-func installNoRecommends(packages []string) {
+-	installPackagesImpl(packages, 3, true)
++// Returns the packages that could not be installed.
++func installNoRecommends(packages []string) []string {
++	return installPackagesImpl(packages, 3, true)
+ }
+ 
+-func installPackagesImpl(packages []string, retries int, noRecommends bool) {
++func installPackagesImpl(packages []string, retries int, noRecommends bool) []string {
+ 	if len(packages) == 0 {
+-		return
++		return nil
+ 	}
+ 
+ 	if _, err := exec.LookPath("apt-get"); err != nil {
+ 		printAiPrompt(packages)
+-		return
++		return nil
+ 	}
+ 
+ 	available := getAvailablePackages()
+@@ -125,7 +131,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 
+ 	if len(toInstall) == 0 {
+ 		logToFile("No valid packages to install.")
+-		return
++		return missing
+ 	}
+ 
+ 	pkgString := strings.Join(toInstall, " ")
+@@ -148,41 +154,51 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 	// documented workaround for this class of bug.
+ 	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
+ 
+-	for i := 1; i <= retries; i++ {
+-		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
+-		if err := utils.Exec(cmd); err == nil {
+-			logToFile("✅ Package installation completed.")
+-			return
+-		}
++	logToFile(fmt.Sprintf("Installing %d packages in bulk...", len(toInstall)))
++	if err := utils.Exec(cmd); err == nil {
++		logToFile("✅ Package installation completed.")
++		return missing
++	}
+ 
+-		// Fallback: install one by one so a single broken package
+-		// does not prevent the rest from being installed.
+-		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
+-		var failed []string
+-		for _, pkg := range toInstall {
++	// Fallback: install one by one so a single broken package does not
++	// prevent the rest from being installed. Packages that still fail
++	// after `retries` individual attempts are given up on and reported.
++	logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
++	pending := toInstall
++	for attempt := 1; attempt <= retries && len(pending) > 0; attempt++ {
++		var stillFailing []string
++		for _, pkg := range pending {
+ 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
+ 			if err := utils.Exec(singleCmd); err != nil {
+-				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
+-				failed = append(failed, pkg)
++				stillFailing = append(stillFailing, pkg)
+ 			}
+ 		}
+-
+-		if len(failed) > 0 {
+-			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
+-		} else {
+-			logToFile("✅ All packages installed successfully (one by one).")
++		pending = stillFailing
++		if len(pending) > 0 && attempt < retries {
++			logToFile(fmt.Sprintf("⚠️  %d packages still failing after attempt %d/%d, retrying: %v", len(pending), attempt, retries, pending))
+ 		}
+-		return
+ 	}
++
++	if len(pending) > 0 {
++		logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(pending), pending))
++	} else {
++		logToFile("✅ All packages installed successfully (one by one).")
++	}
++
++	return append(missing, pending...)
+ }
+ 
+ // installInteractive installs packages without suppressing debconf prompts.
+ // Use this for packages that require user interaction (e.g. license acceptance).
+ // Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+ // live prompt from the real terminal (see the comment in installPackagesImpl).
+-func installInteractive(packages []string) {
++// Returns the packages that could not be installed (missing from apt's
++// cache, or the whole batch if the bulk apt-get call failed -- interactive
++// packages are typically few and license-related, so we don't attempt the
++// one-by-one isolation used for regular packages).
++func installInteractive(packages []string) []string {
+ 	if len(packages) == 0 {
+-		return
++		return nil
+ 	}
+ 
+ 	available := getAvailablePackages()
+@@ -206,7 +222,7 @@ func installInteractive(packages []string) {
+ 	}
+ 
+ 	if len(toInstall) == 0 {
+-		return
++		return missing
+ 	}
+ 
+ 	pkgString := strings.Join(toInstall, " ")
+@@ -214,7 +230,9 @@ func installInteractive(packages []string) {
+ 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
+ 	if err := utils.Exec(cmd); err != nil {
+ 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
++		return append(missing, toInstall...)
+ 	}
++	return missing
+ }
+ 
+ // removePackages removes packages that the vendor does not want on the system.
+diff --git a/coa/pkg/tailor/wear.go b/coa/pkg/tailor/wear.go
+index 647baa0..8d7452e 100644
+--- a/coa/pkg/tailor/wear.go
++++ b/coa/pkg/tailor/wear.go
+@@ -5,6 +5,7 @@ import (
+ 	"fmt"
+ 	"os"
+ 	"path/filepath"
++	"strings"
+ )
+ 
+ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+@@ -33,7 +34,8 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+ 	}
+ 
+ 	utils.LogNormal("--- Applying Costume: %s ---", suit.Name)
+-	if err := applySuit(costumeDir, suit); err != nil {
++	failedPackages, err := applySuit(costumeDir, suit)
++	if err != nil {
+ 		return err
+ 	}
+ 
+@@ -44,7 +46,8 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+ 			if accYaml := findYaml(accDir); accYaml != "" {
+ 				if accSuit, err := loadSuit(accYaml); err == nil {
+ 					utils.LogNormal("Accessory: %s", accName)
+-					applySuit(accDir, accSuit)
++					accFailed, _ := applySuit(accDir, accSuit)
++					failedPackages = append(failedPackages, accFailed...)
+ 				}
+ 			}
+ 		}
+@@ -55,6 +58,13 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+ 
+ 	utils.LogNormal("✅ Costume applied successfully!")
+ 
++	if len(failedPackages) > 0 {
++		msg := fmt.Sprintf("⚠️  %d package(s) could not be installed:\n  - %s",
++			len(failedPackages), strings.Join(failedPackages, "\n  - "))
++		utils.LogNormal(utils.ColorYellow + msg + utils.ColorReset)
++		logToFile(msg)
++	}
++
+ 	if suit.Reboot {
+ 		utils.LogNormal(utils.ColorYellow + "This costume recommends a reboot to finish applying all changes." + utils.ColorReset)
+ 	}
+@@ -62,7 +72,12 @@ func Wear(costumeName string, noAcc bool, noFirm bool) error {
+ 	return nil
+ }
+ 
+-func applySuit(dir string, suit *Suit) error {
++// applySuit applies a costume/accessory and returns the list of packages
++// that could not be installed (across packages, packages_no_install_recommends
++// and packages_interactive), so the caller can report them to the user.
++func applySuit(dir string, suit *Suit) ([]string, error) {
++	var failedPackages []string
++
+ 	if suit.Sequence != nil && suit.Sequence.Repositories != nil {
+ 		setupRepositories(suit.Sequence.Repositories, suit.Name)
+ 
+@@ -82,19 +97,19 @@ func applySuit(dir string, suit *Suit) error {
+ 
+ 	if len(suit.Packages) > 0 {
+ 		utils.LogNormal("[%s] Attempting package installation: %v", suit.Name, suit.Packages)
+-		installWithRetries(suit.Packages, 3)
++		failedPackages = append(failedPackages, installWithRetries(suit.Packages, 3)...)
+ 	} else {
+ 		utils.LogNormal("[%s] No packages to install.", suit.Name)
+ 	}
+ 
+ 	if len(suit.PackagesNoRecommends) > 0 {
+ 		utils.LogNormal("[%s] Installing packages without recommends: %v", suit.Name, suit.PackagesNoRecommends)
+-		installNoRecommends(suit.PackagesNoRecommends)
++		failedPackages = append(failedPackages, installNoRecommends(suit.PackagesNoRecommends)...)
+ 	}
+ 
+ 	if len(suit.PackagesInteractive) > 0 {
+ 		utils.LogNormal("[%s] Installing interactive packages (license prompts may appear): %v", suit.Name, suit.PackagesInteractive)
+-		installInteractive(suit.PackagesInteractive)
++		failedPackages = append(failedPackages, installInteractive(suit.PackagesInteractive)...)
+ 	}
+ 
+ 	if len(suit.PackagesRemove) > 0 {
+@@ -129,7 +144,7 @@ func applySuit(dir string, suit *Suit) error {
+ 		}
+ 	}
+ 
+-	return nil
++	return failedPackages, nil
+ }
+ 
+ func copySkelToUser() {

--- a/fix2-chunk-installs.patch
+++ b/fix2-chunk-installs.patch
@@ -1,0 +1,146 @@
+diff --git a/coa/pkg/tailor/wear-logic.go b/coa/pkg/tailor/wear-logic.go
+index 2ff854c..70b18d9 100644
+--- a/coa/pkg/tailor/wear-logic.go
++++ b/coa/pkg/tailor/wear-logic.go
+@@ -84,6 +84,22 @@ func getAvailablePackages() map[string]struct{} {
+ 	return available
+ }
+ 
++// batchSize caps how many packages go into a single apt-get invocation.
++// A single apt-get install with hundreds of packages runs dpkg's trigger
++// processing (initramfs regeneration, DKMS module builds, icon/mime
++// caches, etc.) for the whole batch in one shot at the end, which can be
++// a serious memory/CPU spike on modest VMs and, worse, if the machine
++// dies mid-transaction (OOM, crash) there is no way to know how far it
++// got and no partial progress to resume from on the next run -- the
++// whole multi-hundred-package install has to restart from scratch.
++// Installing in smaller batches keeps each dpkg transaction's trigger
++// processing small, and each successfully completed batch is durably
++// installed on disk, so a crash mid-way only loses the current batch,
++// not everything: re-running `coa wardrobe wear` will see the earlier
++// batches already satisfied (apt-get install on an installed package is
++// a fast no-op) and continue from where it died.
++const batchSize = 20
++
+ func installWithRetries(packages []string, retries int) {
+ 	installPackagesImpl(packages, retries, false)
+ }
+@@ -128,39 +144,57 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 		return
+ 	}
+ 
+-	pkgString := strings.Join(toInstall, " ")
+ 	flags := "-y"
+ 	if noRecommends {
+ 		flags = "-y --no-install-recommends"
+ 	}
+ 
++	totalBatches := (len(toInstall) + batchSize - 1) / batchSize
++	if totalBatches > 1 {
++		logToFile(fmt.Sprintf("Installing %d packages in %d batches of up to %d, so a crash mid-install only loses the current batch...", len(toInstall), totalBatches, batchSize))
++	}
++
++	for start := 0; start < len(toInstall); start += batchSize {
++		end := start + batchSize
++		if end > len(toInstall) {
++			end = len(toInstall)
++		}
++		batch := toInstall[start:end]
++		batchNum := start/batchSize + 1
++
++		if totalBatches > 1 {
++			logToFile(fmt.Sprintf("Batch %d/%d (packages %d-%d of %d): %v", batchNum, totalBatches, start+1, end, len(toInstall), batch))
++		}
++
++		installBatchWithFallback(batch, retries, flags)
++	}
++}
++
++// installBatchWithFallback installs a single batch in bulk, falling back
++// to one-by-one installation within the batch if the bulk call fails, so
++// that one broken package in a batch doesn't take the rest of that batch
++// down with it.
++func installBatchWithFallback(batch []string, retries int, flags string) {
+ 	// readline: accepts low-priority defaults automatically but shows
+ 	// critical prompts (e.g. firmware license agreements) to the user.
+-	// Dpkg::Use-Pty=0: apt normally runs dpkg inside its own internal
+-	// pseudo-terminal so it can both show the output live and log a copy
+-	// to /var/log/apt/term.log. That mirroring has known bugs (Debian
+-	// #765687, #860931) where the copy written to term.log succeeds but
+-	// the live mirror to the real terminal is silently dropped -- the
+-	// user never sees the prompt (or sees it truncated, e.g. "[Más]"
+-	// glued to the next shell prompt) even though stdin/stdout are
+-	// correctly wired to a real tty. Disabling apt's internal pty makes
+-	// dpkg/debconf inherit our own stdio directly instead, which is the
+-	// documented workaround for this class of bug.
+-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkgString)
++	// PAGER=cat prevents firmware license scripts from paginating with
++	// 'more' or 'less', which would block unattended installation.
++	pkgString := strings.Join(batch, " ")
++	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkgString)
+ 
+ 	for i := 1; i <= retries; i++ {
+ 		logToFile(fmt.Sprintf("Installation attempt %d of %d...", i, retries))
+ 		if err := utils.Exec(cmd); err == nil {
+-			logToFile("✅ Package installation completed.")
++			logToFile("✅ Batch installed.")
+ 			return
+ 		}
+ 
+ 		// Fallback: install one by one so a single broken package
+-		// does not prevent the rest from being installed.
+-		logToFile("⚠️  Bulk install failed. Retrying package by package to isolate failures...")
++		// does not prevent the rest of the batch from being installed.
++		logToFile("⚠️  Batch install failed. Retrying package by package to isolate failures...")
+ 		var failed []string
+-		for _, pkg := range toInstall {
+-			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
++		for _, pkg := range batch {
++			singleCmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' %s %s", flags, pkg)
+ 			if err := utils.Exec(singleCmd); err != nil {
+ 				logToFile(fmt.Sprintf("⚠️  Could not install: %s", pkg))
+ 				failed = append(failed, pkg)
+@@ -170,7 +204,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 		if len(failed) > 0 {
+ 			logToFile(fmt.Sprintf("⚠️  %d packages could not be installed: %v", len(failed), failed))
+ 		} else {
+-			logToFile("✅ All packages installed successfully (one by one).")
++			logToFile("✅ All packages in batch installed successfully (one by one).")
+ 		}
+ 		return
+ 	}
+@@ -178,8 +212,7 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) {
+ 
+ // installInteractive installs packages without suppressing debconf prompts.
+ // Use this for packages that require user interaction (e.g. license acceptance).
+-// Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+-// live prompt from the real terminal (see the comment in installPackagesImpl).
++// PAGER=cat is set to avoid firmware license scripts paginating with 'more'/'less'.
+ func installInteractive(packages []string) {
+ 	if len(packages) == 0 {
+ 		return
+@@ -210,7 +243,7 @@ func installInteractive(packages []string) {
+ 	}
+ 
+ 	pkgString := strings.Join(toInstall, " ")
+-	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
++	cmd := fmt.Sprintf("PAGER=cat apt-get install -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+ 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
+ 	if err := utils.Exec(cmd); err != nil {
+ 		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
+@@ -226,13 +259,13 @@ func removePackages(packages []string) {
+ 	}
+ 
+ 	pkgString := strings.Join(packages, " ")
+-	cmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
++	cmd := fmt.Sprintf("PAGER=cat DEBIAN_FRONTEND=readline apt-get remove -o Dpkg::Options::='--force-confold' -y %s", pkgString)
+ 	logToFile(fmt.Sprintf("Removing packages: %s", pkgString))
+ 	if err := utils.Exec(cmd); err != nil {
+ 		logToFile(fmt.Sprintf("⚠️  Some packages could not be removed (may not be installed): %v", err))
+ 	}
+ 
+-	utils.Exec("DEBIAN_FRONTEND=readline apt-get autoremove -o Dpkg::Use-Pty=0 -y")
++	utils.Exec("PAGER=cat DEBIAN_FRONTEND=readline apt-get autoremove -y")
+ }
+ 
+ func printAiPrompt(packages []string) {

--- a/fix3-verify-dpkg.patch
+++ b/fix3-verify-dpkg.patch
@@ -1,0 +1,66 @@
+diff --git a/coa/pkg/tailor/wear-logic.go b/coa/pkg/tailor/wear-logic.go
+index 62d9ce6..8fc8231 100644
+--- a/coa/pkg/tailor/wear-logic.go
++++ b/coa/pkg/tailor/wear-logic.go
+@@ -170,7 +170,18 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
+ 		for _, pkg := range pending {
+ 			singleCmd := fmt.Sprintf("DEBIAN_FRONTEND=readline apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 %s %s", flags, pkg)
+ 			if err := utils.Exec(singleCmd); err != nil {
+-				stillFailing = append(stillFailing, pkg)
++				// apt-get's exit code alone is not reliable evidence that
++				// THIS package failed: dpkg processes deferred triggers
++				// from unrelated packages during this same invocation, and
++				// a trigger failure poisons the exit code of whatever
++				// install call happened to flush it, even though the
++				// package we actually asked for installed correctly.
++				// Double-check with dpkg before believing the failure.
++				if isPackageInstalled(pkg) {
++					logToFile(fmt.Sprintf("ℹ️  apt-get reported an error installing %s, but dpkg confirms it is installed correctly (likely an unrelated deferred trigger) -- not counting as failed.", pkg))
++				} else {
++					stillFailing = append(stillFailing, pkg)
++				}
+ 			}
+ 		}
+ 		pending = stillFailing
+@@ -188,6 +199,19 @@ func installPackagesImpl(packages []string, retries int, noRecommends bool) []st
+ 	return append(missing, pending...)
+ }
+ 
++// isPackageInstalled reports whether dpkg considers pkg to be correctly
++// and fully installed ("install ok installed"), independent of what the
++// most recent apt-get call's exit code said. Used to avoid false-positive
++// failure reports caused by unrelated deferred dpkg triggers poisoning an
++// otherwise-successful package's apt-get exit code.
++func isPackageInstalled(pkg string) bool {
++	out, err := utils.ExecCapture(fmt.Sprintf("dpkg-query -W -f='${Status}' %s 2>/dev/null", pkg))
++	if err != nil {
++		return false
++	}
++	return strings.Contains(out, "install ok installed")
++}
++
+ // installInteractive installs packages without suppressing debconf prompts.
+ // Use this for packages that require user interaction (e.g. license acceptance).
+ // Dpkg::Use-Pty=0 avoids apt's internal pty-mirroring bug that can drop the
+@@ -229,8 +253,19 @@ func installInteractive(packages []string) []string {
+ 	cmd := fmt.Sprintf("apt-get install -o Dpkg::Options::='--force-confold' -o Dpkg::Use-Pty=0 -y %s", pkgString)
+ 	logToFile(fmt.Sprintf("Installing interactive packages: %s", pkgString))
+ 	if err := utils.Exec(cmd); err != nil {
+-		logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", err))
+-		return append(missing, toInstall...)
++		// Don't trust apt-get's exit code blindly: check each package
++		// against dpkg before reporting it as failed (see the comment on
++		// isPackageInstalled for why apt-get's exit code alone can lie).
++		var stillFailing []string
++		for _, pkg := range toInstall {
++			if !isPackageInstalled(pkg) {
++				stillFailing = append(stillFailing, pkg)
++			}
++		}
++		if len(stillFailing) > 0 {
++			logToFile(fmt.Sprintf("⚠️  Some interactive packages could not be installed: %v", stillFailing))
++		}
++		return append(missing, stillFailing...)
+ 	}
+ 	return missing
+ }


### PR DESCRIPTION
**Declarative package reconciliation against a full manifest (v1)**

Introduces `packages_manifest `in index.yaml: a file listing the complete, exact set of packages the system should end up with _(plain names or dpkg -l output)_. After the regular install steps, wear reconciles the system against it: anything missing gets installed; anything installed that is not in the manifest gets purged, except a hardcoded safety net _(`neverPurgeBase`)_ and the running kernel. This is what makes a wardrobe authoritative instead of purely additive: a vendor building on top of a standard desktop image can finally express _"the final system has exactly this package set"._

**Depends on:**` fix/wardrobe-chunk-package-installs`. Superseded in practice by` fix/wardrobe-dkms-retry`.